### PR TITLE
Fix IdentificationOtherError dialog

### DIFF
--- a/app/src/main/kotlin/de/digitalService/useID/ui/components/ScanErrorScreen.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/components/ScanErrorScreen.kt
@@ -24,13 +24,15 @@ fun ScanErrorScreen(
     showErrorCard: Boolean = false,
     confirmNavigationButtonDialog: Boolean = false,
     onNavigationButtonClicked: () -> Unit,
-    onButtonClicked: () -> Unit
+    onButtonClicked: () -> Unit,
+    isIdentification: Boolean = false
 ) {
     ScreenWithTopBar(
         navigationButton = NavigationButton(
             icon = NavigationIcon.Cancel,
             shouldShowConfirmDialog = confirmNavigationButtonDialog,
-            onClick = onNavigationButtonClicked
+            onClick = onNavigationButtonClicked,
+            isIdentification = isIdentification
         )
     ) { topPadding ->
         Column(

--- a/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/IdentificationCoordinator.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/IdentificationCoordinator.kt
@@ -100,7 +100,7 @@ class IdentificationCoordinator @Inject constructor(
         identificationFlowCoroutineScope?.cancel()
         val popToRoot = reachedScanState
         CoroutineScope(Dispatchers.Main).launch {
-            if (didSetup && !popToRoot) {
+            if (!didSetup && !popToRoot) {
                 appCoordinator.popUpTo(SetupIntroDestination)
             } else {
                 appCoordinator.popToRoot()

--- a/app/src/main/kotlin/de/digitalService/useID/ui/screens/error/IdentificationOtherError.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/screens/error/IdentificationOtherError.kt
@@ -22,7 +22,8 @@ fun IdentificationOtherError(viewModel: IdentificationOtherErrorViewModel = hilt
         buttonTitleResId = R.string.identification_fetchMetadataError_retry,
         confirmNavigationButtonDialog = true,
         onNavigationButtonClicked = viewModel::onCancelButtonClicked,
-        onButtonClicked = viewModel::onRetryButtonClicked
+        onButtonClicked = viewModel::onRetryButtonClicked,
+        isIdentification = true
     )
 }
 

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/IdentificationCoordinatorTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/IdentificationCoordinatorTest.kt
@@ -347,7 +347,7 @@ class IdentificationCoordinatorTest {
 
         advanceUntilIdle()
 
-        verify(exactly = 1) { mockAppCoordinator.popToRoot() }
+        verify(exactly = 1) { mockAppCoordinator.popUpTo(SetupIntroDestination) }
 
         job.cancel()
     }
@@ -414,7 +414,7 @@ class IdentificationCoordinatorTest {
 
         advanceUntilIdle()
 
-        verify(exactly = 1) { mockAppCoordinator.popUpTo(SetupIntroDestination) }
+        verify(exactly = 1) { mockAppCoordinator.popToRoot() }
 
         job.cancel()
     }


### PR DESCRIPTION
The problem described in this [ticket](https://digitalservicebund.atlassian.net/browse/USEID-762) could be partially reproduced.

What I was able to reproduce and fix:
_"Confirmation dialog asks for cancelling setup "_ -> The wrong cancellation dialog was shown

What I could not reproduce:
_"... confirming leads to setup intro"_ -> As far as I could test it, I was correctly navigated back to the homescreen