### PR TITLE
Bugfixing

### DIFF
--- a/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/AppCoordinator.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/AppCoordinator.kt
@@ -58,8 +58,8 @@ class AppCoordinator @Inject constructor(
 
     override fun homeScreenLaunched() {
         if (coldLaunch &&
-            setupCoordinator.stateFlow.value != SubCoordinatorState.Active &&
-            identificationCoordinator.stateFlow.value != SubCoordinatorState.Active &&
+            setupCoordinator.stateFlow.value != SubCoordinatorState.ACTIVE &&
+            identificationCoordinator.stateFlow.value != SubCoordinatorState.ACTIVE &&
             storageManager.firstTimeUser
         ) {
             offerIdSetup(null)

--- a/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/CanCoordinator.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/CanCoordinator.kt
@@ -74,7 +74,7 @@ class CanCoordinator @Inject constructor(
 
     private var eIdEventFlowCoroutineScope: Job? = null
 
-    private val _stateFlow: MutableStateFlow<SubCoordinatorState> = MutableStateFlow(SubCoordinatorState.Finished)
+    private val _stateFlow: MutableStateFlow<SubCoordinatorState> = MutableStateFlow(SubCoordinatorState.FINISHED)
     val stateFlow: StateFlow<SubCoordinatorState>
         get() = _stateFlow
 
@@ -91,7 +91,7 @@ class CanCoordinator @Inject constructor(
     private fun startCanFlow(): Flow<SubCoordinatorState> {
         collectEidEvents()
 
-        _stateFlow.value = SubCoordinatorState.Active
+        _stateFlow.value = SubCoordinatorState.ACTIVE
         return stateFlow
     }
 
@@ -165,12 +165,17 @@ class CanCoordinator @Inject constructor(
     }
 
     fun cancelCanFlow() {
-        _stateFlow.value = SubCoordinatorState.Cancelled
+        _stateFlow.value = SubCoordinatorState.CANCELLED
         resetCoordinatorState()
     }
 
-    private fun finishCanFlow() {
-        _stateFlow.value = SubCoordinatorState.Finished
+    fun finishCanFlow() {
+        _stateFlow.value = SubCoordinatorState.FINISHED
+        resetCoordinatorState()
+    }
+
+    fun skipCanFlow() {
+        _stateFlow.value = SubCoordinatorState.SKIPPED
         resetCoordinatorState()
     }
 

--- a/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/CanCoordinator.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/CanCoordinator.kt
@@ -226,7 +226,7 @@ class CanCoordinator @Inject constructor(
                         }
                     }
                     is EidInteractionEvent.AuthenticationSuccessful, EidInteractionEvent.ProcessCompletedSuccessfullyWithoutResult, is EidInteractionEvent.ProcessCompletedSuccessfullyWithRedirect -> finishCanFlow()
-                    is EidInteractionEvent.Error -> cancelCanFlow()
+                    is EidInteractionEvent.Error -> finishCanFlow()
                     else -> logger.debug("Ignoring event: $event")
                 }
             }

--- a/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/IdentificationCoordinator.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/IdentificationCoordinator.kt
@@ -218,7 +218,7 @@ class IdentificationCoordinator @Inject constructor(
                                 canCoordinator.startIdentCanFlow(pin.takeIf { !startedWithThreeAttempts }).collect { state ->
                                     when (state) {
                                         SubCoordinatorState.Cancelled -> cancelIdentification()
-                                        else -> logger.debug("Ignoring sub flow event: $event")
+                                        else -> logger.debug("Ignoring sub flow event: $state")
                                     }
                                 }
                             }

--- a/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/IdentificationCoordinator.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/IdentificationCoordinator.kt
@@ -53,7 +53,7 @@ class IdentificationCoordinator @Inject constructor(
     private var eIdEventFlowCoroutineScope: Job? = null
     private var canEventFlowCoroutineScope: Job? = null
 
-    val stateFlow: MutableStateFlow<SubCoordinatorState> = MutableStateFlow(SubCoordinatorState.Finished)
+    val stateFlow: MutableStateFlow<SubCoordinatorState> = MutableStateFlow(SubCoordinatorState.FINISHED)
 
     fun startIdentificationProcess(tcTokenUrl: String, setupSkipped: Boolean) {
         this.setupSkipped = setupSkipped
@@ -72,7 +72,7 @@ class IdentificationCoordinator @Inject constructor(
     private fun executeIdentification() {
         logger.debug("Start identification process.")
 
-        stateFlow.value = SubCoordinatorState.Active
+        stateFlow.value = SubCoordinatorState.ACTIVE
 
         eIdEventFlowCoroutineScope?.cancel()
         canEventFlowCoroutineScope?.cancel()
@@ -130,7 +130,7 @@ class IdentificationCoordinator @Inject constructor(
 
         navigator.popToRoot()
 
-        stateFlow.value = SubCoordinatorState.Cancelled
+        stateFlow.value = SubCoordinatorState.CANCELLED
     }
 
     private fun finishIdentification(redirectUrl: String) {
@@ -145,7 +145,7 @@ class IdentificationCoordinator @Inject constructor(
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         ContextCompat.startActivity(context, intent, null)
 
-        stateFlow.value = SubCoordinatorState.Finished
+        stateFlow.value = SubCoordinatorState.FINISHED
     }
 
     private fun collectEidEvents() {
@@ -213,11 +213,11 @@ class IdentificationCoordinator @Inject constructor(
                             return@collect
                         }
 
-                        if (canCoordinator.stateFlow.value != SubCoordinatorState.Active) {
+                        if (canCoordinator.stateFlow.value != SubCoordinatorState.ACTIVE) {
                             canEventFlowCoroutineScope = CoroutineScope(coroutineContextProvider.IO).launch {
                                 canCoordinator.startIdentCanFlow(pin.takeIf { !startedWithThreeAttempts }).collect { state ->
                                     when (state) {
-                                        SubCoordinatorState.Cancelled -> cancelIdentification()
+                                        SubCoordinatorState.CANCELLED -> cancelIdentification()
                                         else -> logger.debug("Ignoring sub flow event: $state")
                                     }
                                 }
@@ -231,7 +231,7 @@ class IdentificationCoordinator @Inject constructor(
                         _scanInProgress.value = false
                         navigator.navigate(IdentificationCardBlockedDestination)
                         idCardManager.cancelTask()
-                        stateFlow.value = SubCoordinatorState.Cancelled
+                        stateFlow.value = SubCoordinatorState.CANCELLED
                         cancel()
                     }
                     is EidInteractionEvent.Error -> {

--- a/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/PinManagementCoordinator.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/PinManagementCoordinator.kt
@@ -223,7 +223,7 @@ class PinManagementCoordinator @Inject constructor(
 
                         if (canCoordinator.stateFlow.value != SubCoordinatorState.Active) {
                             canEventFlowCoroutineScope = CoroutineScope(coroutineContextProvider.IO).launch {
-                                canCoordinator.startSetupCanFlow(intro = startedWithThreeAttempts, oldPin, newPin).collect { state ->
+                                canCoordinator.startPinManagementCanFlow(shortFlow = !startedWithThreeAttempts, oldPin, newPin).collect { state ->
                                     when (state) {
                                         SubCoordinatorState.Cancelled -> cancelPinManagementAndNavigate(null)
                                         SubCoordinatorState.Finished -> finishPinManagementFlow()

--- a/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/PinManagementCoordinator.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/PinManagementCoordinator.kt
@@ -114,6 +114,7 @@ class PinManagementCoordinator @Inject constructor(
 
     fun onBack() {
         navigator.pop()
+        reachedScanState = false
         cancelIdCardManagerTasks()
     }
 
@@ -149,6 +150,7 @@ class PinManagementCoordinator @Inject constructor(
         newPin = null
         firstOldPinRequest = true
         backAllowed = true
+        reachedScanState = false
         eIdEventFlowCoroutineScope?.cancel()
         canEventFlowCoroutineScope?.cancel()
     }
@@ -162,16 +164,16 @@ class PinManagementCoordinator @Inject constructor(
                 when (event) {
                     EidInteractionEvent.RequestCardInsertion -> {
                         logger.debug("Card insertion requested.")
-                        if (canCoordinator.stateFlow.value != SubCoordinatorState.ACTIVE) {
-                            logger.debug("Requested card insertion without subflow active. Pushing scan screen.")
-                            navigator.navigatePopping(SetupScanDestination)
-                        } else {
-                            logger.debug("Requested card insertion with active subflow. Popping to scan screen.")
+
+                        if (reachedScanState) {
+                            logger.debug("Popping to scan screen.")
                             backAllowed = false
                             navigator.popUpTo(SetupScanDestination)
+                        } else {
+                            logger.debug("Pushing scan screen.")
+                            navigator.navigatePopping(SetupScanDestination)
+                            reachedScanState = true
                         }
-
-                        reachedScanState = true
                     }
                     EidInteractionEvent.PinManagementStarted -> logger.debug("PIN management started.")
                     EidInteractionEvent.CardRecognized -> {

--- a/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/SubCoordinatorState.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/SubCoordinatorState.kt
@@ -1,5 +1,5 @@
 package de.digitalService.useID.ui.coordinators
 
 enum class SubCoordinatorState {
-    Active, Finished, Cancelled
+    ACTIVE, FINISHED, CANCELLED, SKIPPED
 }

--- a/app/src/main/kotlin/de/digitalService/useID/ui/navigation/AppNavigator.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/navigation/AppNavigator.kt
@@ -5,9 +5,7 @@ import com.ramcosta.composedestinations.navigation.navigate
 import com.ramcosta.composedestinations.spec.Direction
 import de.digitalService.useID.ui.screens.destinations.Destination
 import de.digitalService.useID.ui.screens.destinations.HomeScreenDestination
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -43,6 +41,10 @@ class AppNavigator @Inject constructor() : Navigator {
     }
 
     override fun popToRoot() {
-        CoroutineScope(Dispatchers.Main).launch { navController.popBackStack(route = HomeScreenDestination.route, inclusive = false) }
+        CoroutineScope(Dispatchers.Main).launch {
+            if (navController.currentBackStackEntry != null) {
+                navController.popBackStack(route = HomeScreenDestination.route, inclusive = false)
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/de/digitalService/useID/ui/screens/can/SetupCanAlreadySetup.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/screens/can/SetupCanAlreadySetup.kt
@@ -106,7 +106,7 @@ class SetupCanAlreadySetupViewModel @Inject constructor(
     }
 
     override fun onFinish() {
-        setupCoordinator.finishSetup()
+        canCoordinator.skipCanFlow()
     }
 }
 

--- a/app/src/preview/kotlin/de/digitalService/useID/idCardInterface/IdCardManager.kt
+++ b/app/src/preview/kotlin/de/digitalService/useID/idCardInterface/IdCardManager.kt
@@ -36,14 +36,14 @@ class IdCardManager {
     }
 
     fun cancelTask() {
-        _eidFlow.value = EidInteractionEvent.Idle
+        CoroutineScope(Dispatchers.IO).launch { _eidFlow.emit(EidInteractionEvent.Idle) }
     }
 
     suspend fun injectEvent(event: EidInteractionEvent) {
-        _eidFlow.emit(event)
+        CoroutineScope(Dispatchers.IO).launch { _eidFlow.emit(event) }
     }
 
     suspend fun injectException(exception: IdCardInteractionException) {
-        _eidFlow.emit(EidInteractionEvent.Error(exception))
+        CoroutineScope(Dispatchers.IO).launch { _eidFlow.emit(EidInteractionEvent.Error(exception)) }
     }
 }

--- a/app/src/preview/kotlin/de/digitalService/useID/ui/screens/PreviewIdentificationScan.kt
+++ b/app/src/preview/kotlin/de/digitalService/useID/ui/screens/PreviewIdentificationScan.kt
@@ -121,7 +121,8 @@ class PreviewIdentificationScanViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.Main) {
             simulateWaiting()
 
-            idCardManager.injectEvent(EidInteractionEvent.RequestPuk({}))
+            idCardManager.injectEvent(EidInteractionEvent.CardInteractionComplete)
+            idCardManager.injectException(IdCardInteractionException.CardBlocked)
         }
         trackerManager.trackScreen("identification/cardBlocked")
     }

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/CanCoordinatorTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/CanCoordinatorTest.kt
@@ -68,7 +68,7 @@ class CanCoordinatorTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun identFlowOneAttempt() = runTest {
+    fun identFlowLongOneCanAttempt() = runTest {
         val mockedPinCallback = mockk<(String, String) -> Unit>(relaxed = true)
 
         val eIdFlow: MutableStateFlow<EidInteractionEvent> = MutableStateFlow(EidInteractionEvent.RequestPinAndCan(mockedPinCallback))
@@ -79,7 +79,7 @@ class CanCoordinatorTest {
 
         Assertions.assertEquals(SubCoordinatorState.Finished, canCoordinator.stateFlow.value)
 
-        canCoordinator.startIdentCanFlow(true)
+        canCoordinator.startIdentCanFlow(null)
 
         Assertions.assertEquals(SubCoordinatorState.Active, canCoordinator.stateFlow.value)
 
@@ -117,7 +117,7 @@ class CanCoordinatorTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun identFlowSecondAttempt() = runTest {
+    fun identFlowLongTwoCanAttempts() = runTest {
         val mockedPinCallback = mockk<(String, String) -> Unit>(relaxed = true)
 
         val eIdFlow: MutableStateFlow<EidInteractionEvent> = MutableStateFlow(EidInteractionEvent.RequestPinAndCan(mockedPinCallback))
@@ -127,7 +127,7 @@ class CanCoordinatorTest {
         val canCoordinator = CanCoordinator(mockAppNavigator, mockIdCardManager, mockCoroutineContextProvider)
 
         val incorrectCan = "999999"
-        canCoordinator.startIdentCanFlow(true)
+        canCoordinator.startIdentCanFlow(null)
         advanceUntilIdle()
         canCoordinator.proceedWithThirdAttempt()
         canCoordinator.finishIntro()
@@ -168,7 +168,7 @@ class CanCoordinatorTest {
 
         val canCoordinator = CanCoordinator(mockAppNavigator, mockIdCardManager, mockCoroutineContextProvider)
 
-        canCoordinator.startIdentCanFlow(true)
+        canCoordinator.startIdentCanFlow(null)
 
         Assertions.assertEquals(SubCoordinatorState.Active, canCoordinator.stateFlow.value)
 
@@ -179,7 +179,7 @@ class CanCoordinatorTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun setupFlowOneAttempt() = runTest {
+    fun setupFlowLongOneCanAttempt() = runTest {
         val mockedPinCallback = mockk<(String, String, String) -> Unit>(relaxed = true)
 
         val eIdFlow: MutableStateFlow<EidInteractionEvent> = MutableStateFlow(EidInteractionEvent.RequestCanAndChangedPin(mockedPinCallback))
@@ -190,7 +190,7 @@ class CanCoordinatorTest {
 
         Assertions.assertEquals(SubCoordinatorState.Finished, canCoordinator.stateFlow.value)
 
-        canCoordinator.startSetupCanFlow(true, pin, newPin)
+        canCoordinator.startPinManagementCanFlow(false, pin, newPin)
 
         Assertions.assertEquals(SubCoordinatorState.Active, canCoordinator.stateFlow.value)
 
@@ -228,7 +228,7 @@ class CanCoordinatorTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun setupFlowSecondAttempt() = runTest {
+    fun setupFlowLongTwoCanAttempts() = runTest {
         val mockedPinCallback = mockk<(String, String, String) -> Unit>(relaxed = true)
 
         val eIdFlow: MutableStateFlow<EidInteractionEvent> = MutableStateFlow(EidInteractionEvent.RequestCanAndChangedPin(mockedPinCallback))
@@ -238,7 +238,7 @@ class CanCoordinatorTest {
         val canCoordinator = CanCoordinator(mockAppNavigator, mockIdCardManager, mockCoroutineContextProvider)
 
         val incorrectCan = "999999"
-        canCoordinator.startSetupCanFlow(true, pin, newPin)
+        canCoordinator.startPinManagementCanFlow(false, pin, newPin)
         advanceUntilIdle()
         canCoordinator.proceedWithThirdAttempt()
         canCoordinator.finishIntro()
@@ -266,7 +266,7 @@ class CanCoordinatorTest {
 
         val canCoordinator = CanCoordinator(mockAppNavigator, mockIdCardManager, mockCoroutineContextProvider)
 
-        canCoordinator.startSetupCanFlow(true, pin, newPin)
+        canCoordinator.startPinManagementCanFlow(true, pin, newPin)
 
         Assertions.assertEquals(SubCoordinatorState.Active, canCoordinator.stateFlow.value)
 
@@ -307,7 +307,7 @@ class CanCoordinatorTest {
 
         val canCoordinator = CanCoordinator(mockAppNavigator, mockIdCardManager, mockCoroutineContextProvider)
 
-        canCoordinator.startIdentCanFlow(true)
+        canCoordinator.startIdentCanFlow(null)
         canCoordinator.cancelCanFlow()
 
         Assertions.assertEquals(SubCoordinatorState.Cancelled, canCoordinator.stateFlow.value)

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/CanCoordinatorTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/CanCoordinatorTest.kt
@@ -77,11 +77,11 @@ class CanCoordinatorTest {
 
         val canCoordinator = CanCoordinator(mockAppNavigator, mockIdCardManager, mockCoroutineContextProvider)
 
-        Assertions.assertEquals(SubCoordinatorState.Finished, canCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.FINISHED, canCoordinator.stateFlow.value)
 
         canCoordinator.startIdentCanFlow(null)
 
-        Assertions.assertEquals(SubCoordinatorState.Active, canCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, canCoordinator.stateFlow.value)
 
         advanceUntilIdle()
 
@@ -112,7 +112,7 @@ class CanCoordinatorTest {
 
         advanceUntilIdle()
 
-        Assertions.assertEquals(SubCoordinatorState.Finished, canCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.FINISHED, canCoordinator.stateFlow.value)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -157,7 +157,7 @@ class CanCoordinatorTest {
 
         advanceUntilIdle()
 
-        Assertions.assertEquals(SubCoordinatorState.Finished, canCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.FINISHED, canCoordinator.stateFlow.value)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -170,7 +170,7 @@ class CanCoordinatorTest {
 
         canCoordinator.startIdentCanFlow(null)
 
-        Assertions.assertEquals(SubCoordinatorState.Active, canCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, canCoordinator.stateFlow.value)
 
         advanceUntilIdle()
 
@@ -188,11 +188,11 @@ class CanCoordinatorTest {
 
         val canCoordinator = CanCoordinator(mockAppNavigator, mockIdCardManager, mockCoroutineContextProvider)
 
-        Assertions.assertEquals(SubCoordinatorState.Finished, canCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.FINISHED, canCoordinator.stateFlow.value)
 
         canCoordinator.startPinManagementCanFlow(false, pin, newPin)
 
-        Assertions.assertEquals(SubCoordinatorState.Active, canCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, canCoordinator.stateFlow.value)
 
         advanceUntilIdle()
 
@@ -223,7 +223,7 @@ class CanCoordinatorTest {
 
         advanceUntilIdle()
 
-        Assertions.assertEquals(SubCoordinatorState.Finished, canCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.FINISHED, canCoordinator.stateFlow.value)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -255,7 +255,7 @@ class CanCoordinatorTest {
 
         advanceUntilIdle()
 
-        Assertions.assertEquals(SubCoordinatorState.Finished, canCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.FINISHED, canCoordinator.stateFlow.value)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -268,7 +268,7 @@ class CanCoordinatorTest {
 
         canCoordinator.startPinManagementCanFlow(true, pin, newPin)
 
-        Assertions.assertEquals(SubCoordinatorState.Active, canCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, canCoordinator.stateFlow.value)
 
         advanceUntilIdle()
 
@@ -310,7 +310,7 @@ class CanCoordinatorTest {
         canCoordinator.startIdentCanFlow(null)
         canCoordinator.cancelCanFlow()
 
-        Assertions.assertEquals(SubCoordinatorState.Cancelled, canCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.CANCELLED, canCoordinator.stateFlow.value)
     }
 
     class EidInteractionEventTypeFactory: DefaultTypeFactory() {

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/IdentificationCoordinatorTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/IdentificationCoordinatorTest.kt
@@ -776,7 +776,7 @@ class IdentificationCoordinatorTest {
         idCardManagerFlow.value = EidInteractionEvent.RequestPinAndCan { _, _ -> }
         advanceUntilIdle()
         Assertions.assertFalse(scanInProgress)
-        verify(exactly = 1) { mockCanCoordinator.startIdentCanFlow(true) }
+        verify(exactly = 1) { mockCanCoordinator.startIdentCanFlow(null) }
 
         scanJob.cancel()
     }
@@ -895,7 +895,7 @@ class IdentificationCoordinatorTest {
         idCardManagerFlow.value = EidInteractionEvent.RequestPinAndCan { _, _ -> }
         advanceUntilIdle()
         Assertions.assertFalse(scanInProgress)
-        verify(exactly = 1) { mockCanCoordinator.startIdentCanFlow(false) }
+        verify(exactly = 1) { mockCanCoordinator.startIdentCanFlow(pin) }
 
         scanJob.cancel()
     }

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/IdentificationCoordinatorTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/IdentificationCoordinatorTest.kt
@@ -160,7 +160,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -218,7 +218,7 @@ class IdentificationCoordinatorTest {
         advanceUntilIdle()
         verify(exactly = 1) { mockNavigator.popToRoot() }
         Assertions.assertEquals(
-            SubCoordinatorState.Finished,
+            SubCoordinatorState.FINISHED,
             identificationCoordinator.stateFlow.value
         )
 
@@ -284,7 +284,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -342,7 +342,7 @@ class IdentificationCoordinatorTest {
         advanceUntilIdle()
         verify(exactly = 1) { mockNavigator.popToRoot() }
         Assertions.assertEquals(
-            SubCoordinatorState.Finished,
+            SubCoordinatorState.FINISHED,
             identificationCoordinator.stateFlow.value
         )
 
@@ -408,7 +408,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -476,7 +476,7 @@ class IdentificationCoordinatorTest {
         advanceUntilIdle()
         verify(exactly = 1) { mockNavigator.popToRoot() }
         Assertions.assertEquals(
-            SubCoordinatorState.Finished,
+            SubCoordinatorState.FINISHED,
             identificationCoordinator.stateFlow.value
         )
 
@@ -542,7 +542,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -629,7 +629,7 @@ class IdentificationCoordinatorTest {
         advanceUntilIdle()
         verify(exactly = 1) { mockNavigator.popToRoot() }
         Assertions.assertEquals(
-            SubCoordinatorState.Finished,
+            SubCoordinatorState.FINISHED,
             identificationCoordinator.stateFlow.value
         )
 
@@ -690,7 +690,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -771,7 +771,7 @@ class IdentificationCoordinatorTest {
         Assertions.assertTrue(scanInProgress)
 
         // CAN FLOW IS STARTED
-        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.Cancelled)
+        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.CANCELLED)
         every { mockCanCoordinator.stateFlow } returns canCoordinatorStateFlow
         idCardManagerFlow.value = EidInteractionEvent.RequestPinAndCan { _, _ -> }
         advanceUntilIdle()
@@ -835,7 +835,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -890,7 +890,7 @@ class IdentificationCoordinatorTest {
         Assertions.assertTrue(scanInProgress)
 
         // CAN FLOW IS STARTED
-        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.Cancelled)
+        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.CANCELLED)
         every { mockCanCoordinator.stateFlow } returns canCoordinatorStateFlow
         idCardManagerFlow.value = EidInteractionEvent.RequestPinAndCan { _, _ -> }
         advanceUntilIdle()
@@ -954,7 +954,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -1015,7 +1015,7 @@ class IdentificationCoordinatorTest {
         verify(exactly = 2) { mockIdCardManager.cancelTask() }
         verify(exactly = 1) { mockNavigator.navigate(IdentificationCardBlockedDestination) }
         Assertions.assertEquals(
-            SubCoordinatorState.Cancelled,
+            SubCoordinatorState.CANCELLED,
             identificationCoordinator.stateFlow.value
         )
 
@@ -1025,7 +1025,7 @@ class IdentificationCoordinatorTest {
         verify(exactly = 1) { mockNavigator.popToRoot() }
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Cancelled,
+            SubCoordinatorState.CANCELLED,
             identificationCoordinator.stateFlow.value
         )
 
@@ -1058,7 +1058,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -1080,7 +1080,7 @@ class IdentificationCoordinatorTest {
         verify(exactly = 1) { mockNavigator.popToRoot() }
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Cancelled,
+            SubCoordinatorState.CANCELLED,
             identificationCoordinator.stateFlow.value
         )
     }
@@ -1132,7 +1132,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -1166,7 +1166,7 @@ class IdentificationCoordinatorTest {
         verify(exactly = 1) { mockNavigator.popToRoot() }
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Cancelled,
+            SubCoordinatorState.CANCELLED,
             identificationCoordinator.stateFlow.value
         )
     }
@@ -1220,7 +1220,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -1264,7 +1264,7 @@ class IdentificationCoordinatorTest {
         verify(exactly = 1) { mockNavigator.popToRoot() }
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Cancelled,
+            SubCoordinatorState.CANCELLED,
             identificationCoordinator.stateFlow.value
         )
     }
@@ -1318,7 +1318,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -1373,7 +1373,7 @@ class IdentificationCoordinatorTest {
         verify(exactly = 1) { mockNavigator.popToRoot() }
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Cancelled,
+            SubCoordinatorState.CANCELLED,
             identificationCoordinator.stateFlow.value
         )
     }
@@ -1439,7 +1439,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -1503,7 +1503,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.cancelIdentification()
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Cancelled,
+            SubCoordinatorState.CANCELLED,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockNavigator.popToRoot() }
@@ -1571,7 +1571,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -1634,7 +1634,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.cancelIdentification()
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Cancelled,
+            SubCoordinatorState.CANCELLED,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockNavigator.popToRoot() }
@@ -1702,7 +1702,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -1776,7 +1776,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.cancelIdentification()
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Cancelled,
+            SubCoordinatorState.CANCELLED,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockNavigator.popToRoot() }
@@ -1844,7 +1844,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -1911,7 +1911,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.cancelIdentification()
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Cancelled,
+            SubCoordinatorState.CANCELLED,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockNavigator.popToRoot() }
@@ -1979,7 +1979,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -2040,7 +2040,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.cancelIdentification()
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Cancelled,
+            SubCoordinatorState.CANCELLED,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockNavigator.popToRoot() }
@@ -2108,7 +2108,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -2171,7 +2171,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.cancelIdentification()
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Cancelled,
+            SubCoordinatorState.CANCELLED,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockNavigator.popToRoot() }
@@ -2239,7 +2239,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -2302,7 +2302,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.cancelIdentification()
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Cancelled,
+            SubCoordinatorState.CANCELLED,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockNavigator.popToRoot() }
@@ -2370,7 +2370,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockIdCardManager.cancelTask() }
@@ -2437,7 +2437,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.cancelIdentification()
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Cancelled,
+            SubCoordinatorState.CANCELLED,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockNavigator.popToRoot() }
@@ -2478,7 +2478,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.startIdentificationProcess(testTokenURL, setupSkipped)
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Active,
+            SubCoordinatorState.ACTIVE,
             identificationCoordinator.stateFlow.value
         )
 
@@ -2489,7 +2489,7 @@ class IdentificationCoordinatorTest {
         identificationCoordinator.cancelIdentification()
         advanceUntilIdle()
         Assertions.assertEquals(
-            SubCoordinatorState.Cancelled,
+            SubCoordinatorState.CANCELLED,
             identificationCoordinator.stateFlow.value
         )
         verify(exactly = 1) { mockNavigator.popToRoot() }

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/PinManagementCoordinatorTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/PinManagementCoordinatorTest.kt
@@ -409,12 +409,12 @@ class PinManagementCoordinatorTest {
 
         Assertions.assertTrue(progress)
 
-        every { mockCanCoordinator.startSetupCanFlow(false, transportPin, personalPin) } returns canCoordinatorStateFlow
+        every { mockCanCoordinator.startPinManagementCanFlow(true, transportPin, personalPin) } returns canCoordinatorStateFlow
         idCardManagerFlow.value = EidInteractionEvent.RequestCanAndChangedPin { _, _, _ -> }
         advanceUntilIdle()
 
         Assertions.assertFalse(progress)
-        verify(exactly = 1) { mockCanCoordinator.startSetupCanFlow(false, transportPin, personalPin) }
+        verify(exactly = 1) { mockCanCoordinator.startPinManagementCanFlow(true, transportPin, personalPin) }
 
         scanJob.cancel()
         stateJob.cancel()
@@ -522,12 +522,12 @@ class PinManagementCoordinatorTest {
         Assertions.assertTrue(progress)
 
         // CAN
-        every { mockCanCoordinator.startSetupCanFlow(true, transportPin, personalPin) } returns canCoordinatorStateFlow
+        every { mockCanCoordinator.startPinManagementCanFlow(false, transportPin, personalPin) } returns canCoordinatorStateFlow
         idCardManagerFlow.value = EidInteractionEvent.RequestCanAndChangedPin { _, _, _ -> }
         advanceUntilIdle()
 
         Assertions.assertFalse(progress)
-        verify(exactly = 1) { mockCanCoordinator.startSetupCanFlow(true, transportPin, personalPin) }
+        verify(exactly = 1) { mockCanCoordinator.startPinManagementCanFlow(false, transportPin, personalPin) }
 
         scanJob.cancel()
         stateJob.cancel()

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/PinManagementCoordinatorTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/PinManagementCoordinatorTest.kt
@@ -74,7 +74,7 @@ class PinManagementCoordinatorTest {
         val idCardManagerFlow = MutableStateFlow<EidInteractionEvent>(EidInteractionEvent.PinManagementStarted)
         every { mockIdCardManager.eidFlow } returns idCardManagerFlow
 
-        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.Cancelled)
+        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.CANCELLED)
         every { mockCanCoordinator.stateFlow } returns canCoordinatorStateFlow
 
         val pinManagementCoordinator = PinManagementCoordinator(
@@ -93,7 +93,7 @@ class PinManagementCoordinatorTest {
 
         // START PIN MANAGEMENT
         val pinManagementStateFlow = pinManagementCoordinator.startPinManagement(pinStatus = PinStatus.TransportPin)
-        var pinManagementState = SubCoordinatorState.Finished
+        var pinManagementState = SubCoordinatorState.FINISHED
         val stateJob = pinManagementStateFlow
             .onEach { pinManagementState = it }
             .launchIn(CoroutineScope(dispatcher))
@@ -103,7 +103,7 @@ class PinManagementCoordinatorTest {
 
         advanceUntilIdle()
 
-        Assertions.assertEquals(SubCoordinatorState.Active, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, pinManagementState)
 
         // SET CORRECT TRANSPORT PIN
         val transportPin = "12345"
@@ -152,7 +152,7 @@ class PinManagementCoordinatorTest {
         advanceUntilIdle()
 
         Assertions.assertFalse(progress)
-        Assertions.assertEquals(SubCoordinatorState.Finished, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.FINISHED, pinManagementState)
 
         scanJob.cancel()
         stateJob.cancel()
@@ -220,7 +220,7 @@ class PinManagementCoordinatorTest {
         val idCardManagerFlow = MutableStateFlow<EidInteractionEvent>(EidInteractionEvent.PinManagementStarted)
         every { mockIdCardManager.eidFlow } returns idCardManagerFlow
 
-        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.Cancelled)
+        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.CANCELLED)
         every { mockCanCoordinator.stateFlow } returns canCoordinatorStateFlow
 
         val pinManagementCoordinator = PinManagementCoordinator(
@@ -239,7 +239,7 @@ class PinManagementCoordinatorTest {
 
         // START PIN MANAGEMENT
         val pinManagementStateFlow = pinManagementCoordinator.startPinManagement(pinStatus = PinStatus.TransportPin)
-        var pinManagementState = SubCoordinatorState.Finished
+        var pinManagementState = SubCoordinatorState.FINISHED
         val stateJob = pinManagementStateFlow
             .onEach { pinManagementState = it }
             .launchIn(CoroutineScope(dispatcher))
@@ -248,7 +248,7 @@ class PinManagementCoordinatorTest {
         Assertions.assertEquals(SetupTransportPinDestination(false).route, navigationParameter.route)
 
         advanceUntilIdle()
-        Assertions.assertEquals(SubCoordinatorState.Active, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, pinManagementState)
 
         // SET WRONG TRANSPORT PIN
         val transportPin = "12345"
@@ -301,7 +301,7 @@ class PinManagementCoordinatorTest {
         advanceUntilIdle()
 
         Assertions.assertFalse(progress)
-        Assertions.assertEquals(SubCoordinatorState.Active, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, pinManagementState)
 
         navigationParameter = navigationDestinationSlot.captured
         Assertions.assertEquals(SetupTransportPinDestination(true).route, navigationParameter.route)
@@ -328,7 +328,7 @@ class PinManagementCoordinatorTest {
         advanceUntilIdle()
 
         Assertions.assertFalse(progress)
-        Assertions.assertEquals(SubCoordinatorState.Finished, pinManagementState) // Why is this failing?
+        Assertions.assertEquals(SubCoordinatorState.FINISHED, pinManagementState) // Why is this failing?
 
         scanJob.cancel()
         stateJob.cancel()
@@ -344,7 +344,7 @@ class PinManagementCoordinatorTest {
         val idCardManagerFlow = MutableStateFlow<EidInteractionEvent>(EidInteractionEvent.PinManagementStarted)
         every { mockIdCardManager.eidFlow } returns idCardManagerFlow
 
-        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.Cancelled)
+        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.CANCELLED)
         every { mockCanCoordinator.stateFlow } returns canCoordinatorStateFlow
 
         val pinManagementCoordinator = PinManagementCoordinator(
@@ -363,7 +363,7 @@ class PinManagementCoordinatorTest {
 
         // START PIN MANAGEMENT
         val pinManagementStateFlow = pinManagementCoordinator.startPinManagement(pinStatus = PinStatus.TransportPin)
-        var pinManagementState = SubCoordinatorState.Finished
+        var pinManagementState = SubCoordinatorState.FINISHED
         val stateJob = pinManagementStateFlow
             .onEach { pinManagementState = it }
             .launchIn(CoroutineScope(dispatcher))
@@ -372,7 +372,7 @@ class PinManagementCoordinatorTest {
         Assertions.assertEquals(SetupTransportPinDestination(false).route, navigationParameter.route)
 
         advanceUntilIdle()
-        Assertions.assertEquals(pinManagementState, SubCoordinatorState.Active)
+        Assertions.assertEquals(pinManagementState, SubCoordinatorState.ACTIVE)
 
         // SET TRANSPORT PIN
         val transportPin = "12345"
@@ -430,7 +430,7 @@ class PinManagementCoordinatorTest {
         val idCardManagerFlow = MutableStateFlow<EidInteractionEvent>(EidInteractionEvent.PinManagementStarted)
         every { mockIdCardManager.eidFlow } returns idCardManagerFlow
 
-        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.Cancelled)
+        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.CANCELLED)
         every { mockCanCoordinator.stateFlow } returns canCoordinatorStateFlow
 
         val pinManagementCoordinator = PinManagementCoordinator(
@@ -449,7 +449,7 @@ class PinManagementCoordinatorTest {
 
         // START PIN MANAGEMENT
         val pinManagementStateFlow = pinManagementCoordinator.startPinManagement(pinStatus = PinStatus.TransportPin)
-        var pinManagementState = SubCoordinatorState.Finished
+        var pinManagementState = SubCoordinatorState.FINISHED
         val stateJob = pinManagementStateFlow
             .onEach { pinManagementState = it }
             .launchIn(CoroutineScope(dispatcher))
@@ -458,7 +458,7 @@ class PinManagementCoordinatorTest {
         Assertions.assertEquals(SetupTransportPinDestination(false).route, navigationParameter.route)
 
         advanceUntilIdle()
-        Assertions.assertEquals(pinManagementState, SubCoordinatorState.Active)
+        Assertions.assertEquals(pinManagementState, SubCoordinatorState.ACTIVE)
 
         // SET TRANSPORT PIN
         val transportPin = "12345"
@@ -543,7 +543,7 @@ class PinManagementCoordinatorTest {
         val idCardManagerFlow = MutableStateFlow<EidInteractionEvent>(EidInteractionEvent.PinManagementStarted)
         every { mockIdCardManager.eidFlow } returns idCardManagerFlow
 
-        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.Cancelled)
+        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.CANCELLED)
         every { mockCanCoordinator.stateFlow } returns canCoordinatorStateFlow
 
         val pinManagementCoordinator = PinManagementCoordinator(
@@ -562,7 +562,7 @@ class PinManagementCoordinatorTest {
 
         // START PIN MANAGEMENT
         val pinManagementStateFlow = pinManagementCoordinator.startPinManagement(pinStatus = PinStatus.TransportPin)
-        var pinManagementState = SubCoordinatorState.Finished
+        var pinManagementState = SubCoordinatorState.FINISHED
         val stateJob = pinManagementStateFlow
             .onEach { pinManagementState = it }
             .launchIn(CoroutineScope(dispatcher))
@@ -571,7 +571,7 @@ class PinManagementCoordinatorTest {
         Assertions.assertEquals(SetupTransportPinDestination(false).route, navigationParameter.route)
 
         advanceUntilIdle()
-        Assertions.assertEquals(SubCoordinatorState.Active, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, pinManagementState)
 
         // SET TRANSPORT PIN
         val transportPin = "12345"
@@ -612,7 +612,7 @@ class PinManagementCoordinatorTest {
         advanceUntilIdle()
 
         Assertions.assertFalse(progress)
-        Assertions.assertEquals(SubCoordinatorState.Cancelled, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.CANCELLED, pinManagementState)
         verify(exactly = 1) { mockNavigator.navigate(SetupCardBlockedDestination) }
 
         scanJob.cancel()
@@ -629,7 +629,7 @@ class PinManagementCoordinatorTest {
         val idCardManagerFlow = MutableStateFlow<EidInteractionEvent>(EidInteractionEvent.PinManagementStarted)
         every { mockIdCardManager.eidFlow } returns idCardManagerFlow
 
-        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.Cancelled)
+        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.CANCELLED)
         every { mockCanCoordinator.stateFlow } returns canCoordinatorStateFlow
 
         val pinManagementCoordinator = PinManagementCoordinator(
@@ -648,7 +648,7 @@ class PinManagementCoordinatorTest {
 
         // START PIN MANAGEMENT
         val pinManagementStateFlow = pinManagementCoordinator.startPinManagement(pinStatus = PinStatus.TransportPin)
-        var pinManagementState = SubCoordinatorState.Finished
+        var pinManagementState = SubCoordinatorState.FINISHED
         val stateJob = pinManagementStateFlow
             .onEach { pinManagementState = it }
             .launchIn(CoroutineScope(dispatcher))
@@ -657,7 +657,7 @@ class PinManagementCoordinatorTest {
         Assertions.assertEquals(SetupTransportPinDestination(false).route, navigationParameter.route)
 
         advanceUntilIdle()
-        Assertions.assertEquals(SubCoordinatorState.Active, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, pinManagementState)
 
         // SET TRANSPORT PIN
         val transportPin = "12345"
@@ -697,7 +697,7 @@ class PinManagementCoordinatorTest {
         advanceUntilIdle()
 
         Assertions.assertFalse(progress)
-        Assertions.assertEquals(SubCoordinatorState.Cancelled, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.CANCELLED, pinManagementState)
         verify(exactly = 1) { mockNavigator.navigate(SetupOtherErrorDestination) }
 
         scanJob.cancel()
@@ -714,7 +714,7 @@ class PinManagementCoordinatorTest {
         val idCardManagerFlow = MutableStateFlow<EidInteractionEvent>(EidInteractionEvent.PinManagementStarted)
         every { mockIdCardManager.eidFlow } returns idCardManagerFlow
 
-        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.Cancelled)
+        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.CANCELLED)
         every { mockCanCoordinator.stateFlow } returns canCoordinatorStateFlow
 
         val pinManagementCoordinator = PinManagementCoordinator(
@@ -733,7 +733,7 @@ class PinManagementCoordinatorTest {
 
         // START PIN MANAGEMENT
         val pinManagementStateFlow = pinManagementCoordinator.startPinManagement(pinStatus = PinStatus.TransportPin)
-        var pinManagementState = SubCoordinatorState.Finished
+        var pinManagementState = SubCoordinatorState.FINISHED
         val stateJob = pinManagementStateFlow
             .onEach { pinManagementState = it }
             .launchIn(CoroutineScope(dispatcher))
@@ -742,7 +742,7 @@ class PinManagementCoordinatorTest {
         Assertions.assertEquals(SetupTransportPinDestination(false).route, navigationParameter.route)
 
         advanceUntilIdle()
-        Assertions.assertEquals(SubCoordinatorState.Active, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, pinManagementState)
 
         // SET TRANSPORT PIN
         val transportPin = "12345"
@@ -783,7 +783,7 @@ class PinManagementCoordinatorTest {
         advanceUntilIdle()
 
         Assertions.assertFalse(progress)
-        Assertions.assertEquals(SubCoordinatorState.Cancelled, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.CANCELLED, pinManagementState)
         verify(exactly = 1) { mockNavigator.navigate(SetupCardDeactivatedDestination) }
 
         scanJob.cancel()
@@ -800,7 +800,7 @@ class PinManagementCoordinatorTest {
         val idCardManagerFlow = MutableStateFlow<EidInteractionEvent>(EidInteractionEvent.PinManagementStarted)
         every { mockIdCardManager.eidFlow } returns idCardManagerFlow
 
-        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.Cancelled)
+        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.CANCELLED)
         every { mockCanCoordinator.stateFlow } returns canCoordinatorStateFlow
 
         val pinManagementCoordinator = PinManagementCoordinator(
@@ -819,7 +819,7 @@ class PinManagementCoordinatorTest {
 
         // START PIN MANAGEMENT
         val pinManagementStateFlow = pinManagementCoordinator.startPinManagement(pinStatus = PinStatus.TransportPin)
-        var pinManagementState = SubCoordinatorState.Finished
+        var pinManagementState = SubCoordinatorState.FINISHED
         val stateJob = pinManagementStateFlow
             .onEach { pinManagementState = it }
             .launchIn(CoroutineScope(dispatcher))
@@ -828,7 +828,7 @@ class PinManagementCoordinatorTest {
         Assertions.assertEquals(SetupTransportPinDestination(false).route, navigationParameter.route)
 
         advanceUntilIdle()
-        Assertions.assertEquals(SubCoordinatorState.Active, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, pinManagementState)
 
         // SET TRANSPORT PIN
         val transportPin = "12345"
@@ -869,7 +869,7 @@ class PinManagementCoordinatorTest {
         advanceUntilIdle()
 
         Assertions.assertFalse(progress)
-        Assertions.assertEquals(SubCoordinatorState.Cancelled, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.CANCELLED, pinManagementState)
         verify(exactly = 1) { mockNavigator.navigate(SetupCardBlockedDestination) }
 
         scanJob.cancel()
@@ -886,7 +886,7 @@ class PinManagementCoordinatorTest {
         val idCardManagerFlow = MutableStateFlow<EidInteractionEvent>(EidInteractionEvent.PinManagementStarted)
         every { mockIdCardManager.eidFlow } returns idCardManagerFlow
 
-        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.Cancelled)
+        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.CANCELLED)
         every { mockCanCoordinator.stateFlow } returns canCoordinatorStateFlow
 
         val pinManagementCoordinator = PinManagementCoordinator(
@@ -905,7 +905,7 @@ class PinManagementCoordinatorTest {
 
         // START PIN MANAGEMENT
         val pinManagementStateFlow = pinManagementCoordinator.startPinManagement(pinStatus = PinStatus.TransportPin)
-        var pinManagementState = SubCoordinatorState.Finished
+        var pinManagementState = SubCoordinatorState.FINISHED
         val stateJob = pinManagementStateFlow
             .onEach { pinManagementState = it }
             .launchIn(CoroutineScope(dispatcher))
@@ -914,7 +914,7 @@ class PinManagementCoordinatorTest {
         Assertions.assertEquals(SetupTransportPinDestination(false).route, navigationParameter.route)
 
         advanceUntilIdle()
-        Assertions.assertEquals(SubCoordinatorState.Active, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, pinManagementState)
 
         // SET TRANSPORT PIN
         val transportPin = "12345"
@@ -955,14 +955,14 @@ class PinManagementCoordinatorTest {
         advanceUntilIdle()
 
         Assertions.assertFalse(progress)
-        Assertions.assertEquals(SubCoordinatorState.Active, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, pinManagementState)
         navigationParameter = navigationDestinationSlot.captured
         Assertions.assertEquals(SetupCardUnreadableDestination(false).route, navigationParameter.route)
 
         pinManagementCoordinator.retryPinManagement()
         advanceUntilIdle()
 
-        Assertions.assertEquals(SubCoordinatorState.Active, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, pinManagementState)
         verify(exactly = 2) { mockIdCardManager.changePin(mockContext) }
 
         scanJob.cancel()
@@ -979,7 +979,7 @@ class PinManagementCoordinatorTest {
         val idCardManagerFlow = MutableStateFlow<EidInteractionEvent>(EidInteractionEvent.PinManagementStarted)
         every { mockIdCardManager.eidFlow } returns idCardManagerFlow
 
-        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.Cancelled)
+        val canCoordinatorStateFlow = MutableStateFlow(SubCoordinatorState.CANCELLED)
         every { mockCanCoordinator.stateFlow } returns canCoordinatorStateFlow
 
         val pinManagementCoordinator = PinManagementCoordinator(
@@ -998,7 +998,7 @@ class PinManagementCoordinatorTest {
 
         // START PIN MANAGEMENT
         val pinManagementStateFlow = pinManagementCoordinator.startPinManagement(pinStatus = PinStatus.TransportPin)
-        var pinManagementState = SubCoordinatorState.Finished
+        var pinManagementState = SubCoordinatorState.FINISHED
         val stateJob = pinManagementStateFlow
             .onEach { pinManagementState = it }
             .launchIn(CoroutineScope(dispatcher))
@@ -1007,7 +1007,7 @@ class PinManagementCoordinatorTest {
         Assertions.assertEquals(SetupTransportPinDestination(false).route, navigationParameter.route)
 
         advanceUntilIdle()
-        Assertions.assertEquals(SubCoordinatorState.Active, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, pinManagementState)
 
         // SET TRANSPORT PIN
         val transportPin = "12345"
@@ -1047,7 +1047,7 @@ class PinManagementCoordinatorTest {
         advanceUntilIdle()
 
         Assertions.assertFalse(progress)
-        Assertions.assertEquals(SubCoordinatorState.Cancelled, pinManagementState)
+        Assertions.assertEquals(SubCoordinatorState.CANCELLED, pinManagementState)
         verify(exactly = 1) { mockNavigator.navigate(SetupOtherErrorDestination) }
 
         scanJob.cancel()

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/PinManagementCoordinatorTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/PinManagementCoordinatorTest.kt
@@ -513,7 +513,8 @@ class PinManagementCoordinatorTest {
         idCardManagerFlow.value = EidInteractionEvent.RequestCardInsertion
         advanceUntilIdle()
 
-        verify(exactly = 2) { mockNavigator.navigatePopping(SetupScanDestination) }
+        verify(exactly = 1) { mockNavigator.navigatePopping(SetupScanDestination) }
+        verify(exactly = 1) { mockNavigator.popUpTo(SetupScanDestination) }
         Assertions.assertFalse(progress)
 
         idCardManagerFlow.value = EidInteractionEvent.CardRecognized

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/SetupCoordinatorTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/SetupCoordinatorTest.kt
@@ -75,7 +75,7 @@ class SetupCoordinatorTest {
 
         every { mockCoroutineContextProvider.IO } returns dispatcher
 
-        val pinManagementFlow = MutableStateFlow(SubCoordinatorState.Active)
+        val pinManagementFlow = MutableStateFlow(SubCoordinatorState.ACTIVE)
         every { mockPinManagementCoordinator.startPinManagement(PinStatus.TransportPin) } returns pinManagementFlow
 
         val setupCoordinator = SetupCoordinator(
@@ -90,7 +90,7 @@ class SetupCoordinatorTest {
         advanceUntilIdle()
         verify(exactly = 1) { mockPinManagementCoordinator.startPinManagement(PinStatus.TransportPin) }
 
-        pinManagementFlow.value = SubCoordinatorState.Cancelled
+        pinManagementFlow.value = SubCoordinatorState.CANCELLED
         advanceUntilIdle()
         verify(exactly = 1) { setupCoordinator.cancelSetup() }
         verify(exactly = 1) { mockNavigator.popToRoot() }
@@ -101,7 +101,7 @@ class SetupCoordinatorTest {
 
         every { mockCoroutineContextProvider.IO } returns dispatcher
 
-        val pinManagementFlow = MutableStateFlow(SubCoordinatorState.Active)
+        val pinManagementFlow = MutableStateFlow(SubCoordinatorState.ACTIVE)
         every { mockPinManagementCoordinator.startPinManagement(PinStatus.TransportPin) } returns pinManagementFlow
 
         val setupCoordinator = SetupCoordinator(
@@ -116,7 +116,7 @@ class SetupCoordinatorTest {
         advanceUntilIdle()
         verify(exactly = 1) { mockPinManagementCoordinator.startPinManagement(PinStatus.TransportPin) }
 
-        pinManagementFlow.value = SubCoordinatorState.Finished
+        pinManagementFlow.value = SubCoordinatorState.FINISHED
         advanceUntilIdle()
         verify(exactly = 1) { mockNavigator.navigate(SetupFinishDestination) }
     }
@@ -147,11 +147,11 @@ class SetupCoordinatorTest {
         )
 
         setupCoordinator.showSetupIntro(null)
-        Assertions.assertEquals(SubCoordinatorState.Active, setupCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, setupCoordinator.stateFlow.value)
         setupCoordinator.finishSetup()
 
         verify(exactly = 1) { mockNavigator.popToRoot() }
-        Assertions.assertEquals(SubCoordinatorState.Finished, setupCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.FINISHED, setupCoordinator.stateFlow.value)
     }
 
     @Test
@@ -159,7 +159,7 @@ class SetupCoordinatorTest {
 
         every { mockCoroutineContextProvider.Default } returns dispatcher
 
-        val identificationCoordinatorFlow = MutableStateFlow(SubCoordinatorState.Finished)
+        val identificationCoordinatorFlow = MutableStateFlow(SubCoordinatorState.FINISHED)
         every { mockIdentificationCoordinator.stateFlow } returns identificationCoordinatorFlow
 
         val setupCoordinator = SetupCoordinator(
@@ -173,13 +173,13 @@ class SetupCoordinatorTest {
         val testUrl = "tokenUrl"
 
         setupCoordinator.showSetupIntro(tcTokenUrl = testUrl)
-        Assertions.assertEquals(SubCoordinatorState.Active, setupCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, setupCoordinator.stateFlow.value)
         setupCoordinator.finishSetup()
 
         verify(exactly = 0) { mockNavigator.popToRoot() }
         verify(exactly = 1) { mockIdentificationCoordinator.startIdentificationProcess(testUrl, false) }
 
-        identificationCoordinatorFlow.value = SubCoordinatorState.Finished
+        identificationCoordinatorFlow.value = SubCoordinatorState.FINISHED
         advanceUntilIdle()
         Assertions.assertEquals(false, setupCoordinator.identificationPending)
     }
@@ -212,19 +212,19 @@ class SetupCoordinatorTest {
         val testUrl = "tokenUrl"
 
         setupCoordinator.showSetupIntro(tcTokenUrl = testUrl)
-        Assertions.assertEquals(SubCoordinatorState.Active, setupCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, setupCoordinator.stateFlow.value)
         setupCoordinator.cancelSetup()
 
         verify(exactly = 1) { mockNavigator.popToRoot() }
         advanceUntilIdle()
-        Assertions.assertEquals(SubCoordinatorState.Cancelled, setupCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.CANCELLED, setupCoordinator.stateFlow.value)
     }
 
     @Test
     fun skipSetup() {
         every { mockCoroutineContextProvider.Default } returns dispatcher
 
-        val identificationCoordinatorFlow = MutableStateFlow(SubCoordinatorState.Finished)
+        val identificationCoordinatorFlow = MutableStateFlow(SubCoordinatorState.FINISHED)
         every { mockIdentificationCoordinator.stateFlow } returns identificationCoordinatorFlow
 
         val setupCoordinator = SetupCoordinator(
@@ -238,13 +238,13 @@ class SetupCoordinatorTest {
         val testUrl = "tokenUrl"
 
         setupCoordinator.showSetupIntro(tcTokenUrl = testUrl)
-        Assertions.assertEquals(SubCoordinatorState.Active, setupCoordinator.stateFlow.value)
+        Assertions.assertEquals(SubCoordinatorState.ACTIVE, setupCoordinator.stateFlow.value)
         setupCoordinator.skipSetup()
 
         verify(exactly = 0) { mockNavigator.popToRoot() }
         verify(exactly = 1) { mockIdentificationCoordinator.startIdentificationProcess(testUrl, true) }
 
-        identificationCoordinatorFlow.value = SubCoordinatorState.Finished
+        identificationCoordinatorFlow.value = SubCoordinatorState.FINISHED
     }
 
     @Test


### PR DESCRIPTION
This fixes four issues:

- Prompting the user for PIN input in short CAN flow
- Crash on app launch on some devices
- Error screen "blocked ID" automatically dismissed immediately after shown in CAN flow
- Unreliable handling of skipped setup in CAN flow