### PR TITLE
Fix test report upload issue due to invalid filenames

### DIFF
--- a/.github/workflows/PullRequest.yml
+++ b/.github/workflows/PullRequest.yml
@@ -51,3 +51,4 @@ jobs:
           path: |
             app/build/outputs/androidTest-results
             !app/build/outputs/androidTest-results/**/adb.additional*
+            !app/build/outputs/androidTest-results/**/adb.test_outputfiles*


### PR DESCRIPTION
This fixes the issue in the step of uploading test reports in the Pull Request action: 
`Contains the following character:  Double quote`