### PR TITLE
Fix navigation issue after skipping setup

### DIFF
--- a/app/src/androidTestDeviceDebug/kotlin/de/digitalService/useID/userFlowTests/setupAndIdentFlows/SkipSetupAndReturnToSetupOnIdentStart.kt
+++ b/app/src/androidTestDeviceDebug/kotlin/de/digitalService/useID/userFlowTests/setupAndIdentFlows/SkipSetupAndReturnToSetupOnIdentStart.kt
@@ -1,0 +1,135 @@
+package de.digitalService.useID.userFlowTests.setupAndIdentFlows
+
+import android.net.Uri
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.espresso.intent.rule.IntentsTestRule
+import dagger.hilt.android.testing.BindValue
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
+import de.digitalService.useID.MainActivity
+import de.digitalService.useID.StorageManager
+import de.digitalService.useID.analytics.TrackerManagerType
+import de.digitalService.useID.hilt.CoroutineContextProviderModule
+import de.digitalService.useID.hilt.NfcInterfaceMangerModule
+import de.digitalService.useID.hilt.SingletonModule
+import de.digitalService.useID.idCardInterface.EidInteractionEvent
+import de.digitalService.useID.idCardInterface.IdCardManager
+import de.digitalService.useID.models.NfcAvailability
+import de.digitalService.useID.ui.UseIDApp
+import de.digitalService.useID.ui.coordinators.AppCoordinatorType
+import de.digitalService.useID.ui.navigation.Navigator
+import de.digitalService.useID.userFlowTests.setupFlows.TestScreen
+import de.digitalService.useID.userFlowTests.utils.flowParts.ident.runIdentSuccessful
+import de.digitalService.useID.userFlowTests.utils.flowParts.runSetupSuccessful
+import de.digitalService.useID.util.CoroutineContextProviderType
+import de.digitalService.useID.util.NfcInterfaceManagerType
+import de.digitalService.useID.util.setContentUsingUseIdTheme
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import javax.inject.Inject
+
+@UninstallModules(SingletonModule::class, CoroutineContextProviderModule::class, NfcInterfaceMangerModule::class)
+@HiltAndroidTest
+class SkipSetupAndReturnToSetupOnIdentStart {
+    @get:Rule(order = 0)
+    var hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val intentsTestRule = IntentsTestRule(MainActivity::class.java)
+
+    @get:Rule(order = 2)
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Inject
+    lateinit var navigator: Navigator
+
+    @Inject
+    lateinit var trackerManager: TrackerManagerType
+
+    @Inject
+    lateinit var appCoordinator: AppCoordinatorType
+
+    @BindValue
+    val mockIdCardManager: IdCardManager = mockk(relaxed = true)
+
+    @BindValue
+    val mockStorageManager: StorageManager = mockk(relaxed = true) {
+        every { firstTimeUser } returns true
+    }
+
+    @BindValue
+    val mockCoroutineContextProvider: CoroutineContextProviderType = mockk {
+        every { Main } returns Dispatchers.Main
+    }
+
+    @BindValue
+    val mockNfcInterfaceManager: NfcInterfaceManagerType = mockk(relaxed = true){
+        every { nfcAvailability } returns MutableStateFlow(NfcAvailability.Available)
+    }
+
+    private val deepLink = Uri.parse("bundesident://127.0.0.1:24727/eID-Client?tcTokenURL=https%3A%2F%2Feid.digitalservicebund.de%2Fapi%2Fv1%2Fidentification%2Fsessions%2F30d20d97-cf31-4f01-ab27-35dea918bb83%2Ftc-token")
+
+    @Before
+    fun before() {
+        hiltRule.inject()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun skipSetupAndReturnToSetupOnFirstIdentScreenAndFinishSetup() = runTest {
+        every { mockCoroutineContextProvider.IO } returns StandardTestDispatcher(testScheduler)
+        every { mockCoroutineContextProvider.Default } returns StandardTestDispatcher(testScheduler)
+
+        val eidFlow = MutableStateFlow<EidInteractionEvent>(EidInteractionEvent.Idle)
+        every { mockIdCardManager.eidFlow } returns eidFlow
+
+        composeTestRule.activity.setContentUsingUseIdTheme {
+            UseIDApp(
+                nfcAvailability = NfcAvailability.Available,
+                navigator = navigator,
+                trackerManager = trackerManager
+            )
+        }
+
+        val setupIntro = TestScreen.SetupIntro(composeTestRule)
+        val fetchMetadata = TestScreen.IdentificationFetchMetaData(composeTestRule)
+        val setupFinish = TestScreen.SetupFinish(composeTestRule)
+
+        composeTestRule.waitForIdle()
+
+        appCoordinator.handleDeepLink(deepLink)
+        advanceUntilIdle()
+
+        setupIntro.alreadySetupBtn.click()
+        eidFlow.value = EidInteractionEvent.AuthenticationStarted
+        advanceUntilIdle()
+
+        fetchMetadata.back.click()
+        advanceUntilIdle()
+
+        runSetupSuccessful(
+            testRule = composeTestRule,
+            eidFlow = eidFlow,
+            testScope = this
+        )
+
+        setupFinish.setIdentPending(true).assertIsDisplayed()
+        setupFinish.identifyNowBtn.click()
+
+        runIdentSuccessful(
+            testRule = composeTestRule,
+            eidFlow = eidFlow,
+            testScope = this
+        )
+    }
+}

--- a/app/src/main/kotlin/de/digitalService/useID/flows/SetupStateMachine.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/flows/SetupStateMachine.kt
@@ -75,6 +75,7 @@ class SetupStateMachine(initialState: State) {
             is Event.StartSetup -> {
                 when (val currentState = state.value.second) {
                     is State.Intro -> State.StartSetup(currentState.tcTokenUrl)
+                    is State.SkippingToIdentRequested -> State.StartSetup(currentState.tcTokenUrl)
                     else -> throw IllegalArgumentException()
                 }
             }

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/stateMachines/SetupStateMachineTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/stateMachines/SetupStateMachineTest.kt
@@ -88,6 +88,17 @@ class SetupStateMachineTest {
     }
 
     @Test
+    fun `start setup with url after previously skipped setup`() = runTest {
+        val tcTokenUrl = "tcTokenUrl"
+
+        val event = SetupStateMachine.Event.StartSetup
+        val oldState = SetupStateMachine.State.SkippingToIdentRequested(tcTokenUrl)
+        val newState: SetupStateMachine.State.StartSetup = transition(oldState, event, this)
+
+        Assertions.assertEquals(tcTokenUrl, newState.tcTokenUrl)
+    }
+
+    @Test
     fun `start setup without url`() = runTest {
         val event = SetupStateMachine.Event.StartSetup
         val oldState = SetupStateMachine.State.Intro(null)
@@ -285,7 +296,7 @@ class SetupStateMachineTest {
         }
 
         @ParameterizedTest
-        @SealedClassesSource(names = ["Intro"] , mode = SealedClassesSource.Mode.EXCLUDE, factoryClass = SetupStateFactory::class)
+        @SealedClassesSource(names = ["Intro", "SkippingToIdentRequested"] , mode = SealedClassesSource.Mode.EXCLUDE, factoryClass = SetupStateFactory::class)
         fun `start setup`(oldState: SetupStateMachine.State) = runTest {
             val event = SetupStateMachine.Event.StartSetup
 
@@ -299,17 +310,6 @@ class SetupStateMachineTest {
         @SealedClassesSource(names = ["StartSetup"] , mode = SealedClassesSource.Mode.EXCLUDE, factoryClass = SetupStateFactory::class)
         fun `PIN reset`(oldState: SetupStateMachine.State) = runTest {
             val event = SetupStateMachine.Event.ResetPin
-
-            val stateMachine = SetupStateMachine(oldState)
-            Assertions.assertEquals(stateMachine.state.value.second, oldState)
-
-            Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
-        }
-
-        @ParameterizedTest
-        @SealedClassesSource(names = ["Intro"] , mode = SealedClassesSource.Mode.EXCLUDE, factoryClass = SetupStateFactory::class)
-        fun `start PIN management`(oldState: SetupStateMachine.State) = runTest {
-            val event = SetupStateMachine.Event.StartSetup
 
             val stateMachine = SetupStateMachine(oldState)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)


### PR DESCRIPTION
This fixes the following crash after the refactoring: Start ident as first-time user, skip setup, navigate back from first ident screen and enter setup -> Crash.