### PR TITLE
Add error tracking breadcrumbs for state transitions

### DIFF
--- a/app/src/main/kotlin/de/digitalService/useID/MainActivity.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/MainActivity.kt
@@ -60,7 +60,10 @@ class MainActivity : ComponentActivity() {
 
         prepareAppLaunch()
 
-        Sentry.init(sentryDsn)
+        Sentry.init { options ->
+            options.dsn = sentryDsn
+            options.dist = "${BuildConfig.VERSION_CODE}"
+        }
 
         handleNewIntent(intent)
 

--- a/app/src/main/kotlin/de/digitalService/useID/flows/CanStateMachine.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/flows/CanStateMachine.kt
@@ -1,5 +1,6 @@
 package de.digitalService.useID.flows
 
+import de.digitalService.useID.analytics.IssueTrackerManagerType
 import de.digitalService.useID.getLogger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -10,8 +11,8 @@ typealias PinCanCallback = (String, String) -> Unit
 typealias PinManagementCanCallback = (String, String, String) -> Unit
 
 @Singleton
-class CanStateMachine(initialState: State) {
-    @Inject constructor() : this(State.Invalid)
+class CanStateMachine(initialState: State, private val issueTrackerManager: IssueTrackerManagerType) {
+    @Inject constructor(issueTrackerManager: IssueTrackerManagerType) : this(State.Invalid, issueTrackerManager)
 
     private val logger by getLogger()
 
@@ -63,8 +64,12 @@ class CanStateMachine(initialState: State) {
     }
 
     fun transition(event: Event) {
+        val currentStateDescription = state.value.second::class.simpleName
+        val eventDescription = event::class.simpleName
+        issueTrackerManager.addInfoBreadcrumb("transition", "Transitioning from $currentStateDescription via $eventDescription.")
+        logger.debug("$currentStateDescription  ====$eventDescription===>  ???")
         val nextState = nextState(event)
-        logger.debug("${state.value.second::class.simpleName}  ====${event::class.simpleName}===>  ${nextState::class.simpleName}")
+        logger.debug("$currentStateDescription  ====$eventDescription===>  ${nextState::class.simpleName}")
         _state.value = Pair(event, nextState)
     }
 

--- a/app/src/main/kotlin/de/digitalService/useID/flows/IdentificationStateMachine.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/flows/IdentificationStateMachine.kt
@@ -1,5 +1,6 @@
 package de.digitalService.useID.flows
 
+import de.digitalService.useID.analytics.IssueTrackerManagerType
 import de.digitalService.useID.getLogger
 import de.digitalService.useID.idCardInterface.EidAuthenticationRequest
 import de.digitalService.useID.idCardInterface.IdCardAttribute
@@ -13,8 +14,8 @@ typealias AttributeConfirmationCallback = (Map<IdCardAttribute, Boolean>) -> Uni
 typealias PinCallback = (String) -> Unit
 
 @Singleton
-class IdentificationStateMachine(initialState: State) {
-    @Inject constructor() : this(State.Invalid)
+class IdentificationStateMachine(initialState: State, private val issueTrackerManager: IssueTrackerManagerType) {
+    @Inject constructor(issueTrackerManager: IssueTrackerManagerType) : this(State.Invalid, issueTrackerManager)
 
     private val logger by getLogger()
 
@@ -67,9 +68,12 @@ class IdentificationStateMachine(initialState: State) {
     }
 
     fun transition(event: Event) {
-        logger.debug("${state.value.second::class.simpleName}  ====${event::class.simpleName}===>  ???")
+        val currentStateDescription = state.value.second::class.simpleName
+        val eventDescription = event::class.simpleName
+        issueTrackerManager.addInfoBreadcrumb("transition", "Transitioning from $currentStateDescription via $eventDescription.")
+        logger.debug("$currentStateDescription  ====$eventDescription===>  ???")
         val nextState = nextState(event)
-        logger.debug("${state.value.second::class.simpleName}  ====${event::class.simpleName}===>  ${nextState::class.simpleName}")
+        logger.debug("$currentStateDescription  ====$eventDescription===>  ${nextState::class.simpleName}")
         _state.value = Pair(event, nextState)
     }
 

--- a/app/src/main/kotlin/de/digitalService/useID/flows/PinManagementStateMachine.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/flows/PinManagementStateMachine.kt
@@ -1,5 +1,6 @@
 package de.digitalService.useID.flows
 
+import de.digitalService.useID.analytics.IssueTrackerManagerType
 import de.digitalService.useID.getLogger
 import de.digitalService.useID.idCardInterface.IdCardInteractionException
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -10,8 +11,8 @@ import javax.inject.Singleton
 typealias PinManagementCallback = (String, String) -> Unit
 
 @Singleton
-class PinManagementStateMachine(initialState: State) {
-    @Inject constructor() : this(State.Invalid)
+class PinManagementStateMachine(initialState: State, private val issueTrackerManager: IssueTrackerManagerType) {
+    @Inject constructor(issueTrackerManager: IssueTrackerManagerType) : this(State.Invalid, issueTrackerManager)
 
     private val logger by getLogger()
 
@@ -72,8 +73,12 @@ class PinManagementStateMachine(initialState: State) {
     }
 
     fun transition(event: Event) {
+        val currentStateDescription = state.value.second::class.simpleName
+        val eventDescription = event::class.simpleName
+        issueTrackerManager.addInfoBreadcrumb("transition", "Transitioning from $currentStateDescription via $eventDescription.")
+        logger.debug("$currentStateDescription  ====$eventDescription===>  ???")
         val nextState = nextState(event)
-        logger.debug("${state.value.second::class.simpleName}  ====${event::class.simpleName}===>  ${nextState::class.simpleName}")
+        logger.debug("$currentStateDescription  ====$eventDescription===>  ${nextState::class.simpleName}")
         _state.value = Pair(event, nextState)
     }
 

--- a/app/src/main/kotlin/de/digitalService/useID/flows/SetupStateMachine.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/flows/SetupStateMachine.kt
@@ -1,5 +1,6 @@
 package de.digitalService.useID.flows
 
+import de.digitalService.useID.analytics.IssueTrackerManagerType
 import de.digitalService.useID.getLogger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -7,8 +8,8 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class SetupStateMachine(initialState: State) {
-    @Inject constructor() : this(State.Invalid)
+class SetupStateMachine(initialState: State, private val issueTrackerManager: IssueTrackerManagerType) {
+    @Inject constructor(issueTrackerManager: IssueTrackerManagerType) : this(State.Invalid, issueTrackerManager)
 
     private val logger by getLogger()
 
@@ -49,9 +50,12 @@ class SetupStateMachine(initialState: State) {
     }
 
     fun transition(event: Event) {
-        logger.debug("${state.value.second::class.simpleName}  ====${event::class.simpleName}===>  ???")
+        val currentStateDescription = state.value.second::class.simpleName
+        val eventDescription = event::class.simpleName
+        issueTrackerManager.addInfoBreadcrumb("transition", "Transitioning from $currentStateDescription via $eventDescription.")
+        logger.debug("$currentStateDescription  ====$eventDescription===>  ???")
         val nextState = nextState(event)
-        logger.debug("${state.value.second::class.simpleName}  ====${event::class.simpleName}===>  ${nextState::class.simpleName}")
+        logger.debug("$currentStateDescription  ====$eventDescription===>  ${nextState::class.simpleName}")
         _state.value = Pair(event, nextState)
     }
 

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/stateMachines/CanStateMachineTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/stateMachines/CanStateMachineTest.kt
@@ -1,5 +1,6 @@
 package de.digitalService.useID.stateMachines
 
+import de.digitalService.useID.analytics.IssueTrackerManagerType
 import de.digitalService.useID.flows.*
 import de.digitalService.useID.util.CanIdentStateFactory
 import de.digitalService.useID.util.CanPinManagementStateFactory
@@ -23,9 +24,11 @@ class CanStateMachineTest {
     private val pinManagementCallback: PinManagementCanCallback = mockk()
     private val pinCallback: PinCanCallback = mockk()
 
+    private val issueTrackerManager = mockk<IssueTrackerManagerType>(relaxUnitFun = true)
+
     @OptIn(ExperimentalCoroutinesApi::class)
     private inline fun <reified NewState: CanStateMachine.State> transition(initialState: CanStateMachine.State, event: CanStateMachine.Event, testScope: TestScope): NewState {
-        val stateMachine = CanStateMachine(initialState)
+        val stateMachine = CanStateMachine(initialState, issueTrackerManager)
         Assertions.assertEquals(stateMachine.state.value.second, initialState)
 
         stateMachine.transition(event)
@@ -298,7 +301,7 @@ class CanStateMachineTest {
                 val newPin = "000000"
                 val oldState = CanStateMachine.State.PinManagement.CanIntro(identificationPending, pinManagementCallback, oldPin, newPin, true)
 
-                val stateMachine = CanStateMachine(oldState)
+                val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                 Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
             }
 
@@ -514,7 +517,7 @@ class CanStateMachineTest {
             fun back(oldState: CanStateMachine.State.PinManagement) = runTest {
                 val event = CanStateMachine.Event.Back
 
-                val stateMachine = CanStateMachine(oldState)
+                val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                 Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                 Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -531,7 +534,7 @@ class CanStateMachineTest {
                 fun `initialize with pin management callback`(oldState: CanStateMachine.State.PinManagement) = runTest {
                     val event = CanStateMachine.Event.FrameworkRequestsCanForPinManagement(false, "999999", "888888", false, pinManagementCallback)
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -542,7 +545,7 @@ class CanStateMachineTest {
                 fun `initialize with pin callback`(oldState: CanStateMachine.State.PinManagement) = runTest {
                     val event = CanStateMachine.Event.FrameworkRequestsCanForIdent(null, pinCallback)
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -553,7 +556,7 @@ class CanStateMachineTest {
                 fun `agree to third attempt`(oldState: CanStateMachine.State.PinManagement) = runTest {
                     val event = CanStateMachine.Event.AgreeToThirdAttempt
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -564,7 +567,7 @@ class CanStateMachineTest {
                 fun `deny third attempt`(oldState: CanStateMachine.State.PinManagement) = runTest {
                     val event = CanStateMachine.Event.DenyThirdAttempt
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -575,7 +578,7 @@ class CanStateMachineTest {
                 fun `reset PIN`(oldState: CanStateMachine.State.PinManagement) = runTest {
                     val event = CanStateMachine.Event.ResetPin
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -586,7 +589,7 @@ class CanStateMachineTest {
                 fun `confirm CAN intro`(oldState: CanStateMachine.State.PinManagement) = runTest {
                     val event = CanStateMachine.Event.ConfirmCanIntro
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -597,7 +600,7 @@ class CanStateMachineTest {
                 fun `enter CAN`(oldState: CanStateMachine.State.PinManagement) = runTest {
                     val event = CanStateMachine.Event.EnterCan("")
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -608,7 +611,7 @@ class CanStateMachineTest {
                 fun `enter PIN`(oldState: CanStateMachine.State.PinManagement) = runTest {
                     val event = CanStateMachine.Event.EnterPin("")
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -623,7 +626,7 @@ class CanStateMachineTest {
                 fun `initialize with pin management callback`(oldState: CanStateMachine.State.Ident) = runTest {
                     val event = CanStateMachine.Event.FrameworkRequestsCanForPinManagement(false, "999999", "888888", false, pinManagementCallback)
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -634,7 +637,7 @@ class CanStateMachineTest {
                 fun `initialize with pin callback`(oldState: CanStateMachine.State.Ident) = runTest {
                     val event = CanStateMachine.Event.FrameworkRequestsCanForIdent(null, pinCallback)
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -645,7 +648,7 @@ class CanStateMachineTest {
                 fun `agree to third attempt`(oldState: CanStateMachine.State.Ident) = runTest {
                     val event = CanStateMachine.Event.AgreeToThirdAttempt
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -656,7 +659,7 @@ class CanStateMachineTest {
                 fun `deny third attempt`(oldState: CanStateMachine.State.Ident) = runTest {
                     val event = CanStateMachine.Event.DenyThirdAttempt
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -667,7 +670,7 @@ class CanStateMachineTest {
                 fun `reset PIN`(oldState: CanStateMachine.State.Ident) = runTest {
                     val event = CanStateMachine.Event.ResetPin
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -678,7 +681,7 @@ class CanStateMachineTest {
                 fun `confirm CAN intro`(oldState: CanStateMachine.State.Ident) = runTest {
                     val event = CanStateMachine.Event.ConfirmCanIntro
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -689,7 +692,7 @@ class CanStateMachineTest {
                 fun `enter CAN`(oldState: CanStateMachine.State.Ident) = runTest {
                     val event = CanStateMachine.Event.EnterCan("")
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -700,7 +703,7 @@ class CanStateMachineTest {
                 fun `enter PIN`(oldState: CanStateMachine.State.Ident) = runTest {
                     val event = CanStateMachine.Event.EnterPin("")
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -711,7 +714,7 @@ class CanStateMachineTest {
                 fun back(oldState: CanStateMachine.State.Ident) = runTest {
                     val event = CanStateMachine.Event.Back
 
-                    val stateMachine = CanStateMachine(oldState)
+                    val stateMachine = CanStateMachine(oldState, issueTrackerManager)
                     Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
                     Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -724,7 +727,7 @@ class CanStateMachineTest {
         fun `invalidate from pin management state`(oldState: CanStateMachine.State.PinManagement) = runTest {
             val event = CanStateMachine.Event.Invalidate
 
-            val stateMachine = CanStateMachine(oldState)
+            val stateMachine = CanStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             stateMachine.transition(event)
@@ -736,7 +739,7 @@ class CanStateMachineTest {
         fun `invalidate from ident state`(oldState: CanStateMachine.State.Ident) = runTest {
             val event = CanStateMachine.Event.Invalidate
 
-            val stateMachine = CanStateMachine(oldState)
+            val stateMachine = CanStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             stateMachine.transition(event)

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/stateMachines/PinManagementStateMachineTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/stateMachines/PinManagementStateMachineTest.kt
@@ -1,5 +1,6 @@
 package de.digitalService.useID.stateMachines
 
+import de.digitalService.useID.analytics.IssueTrackerManagerType
 import de.digitalService.useID.flows.PinManagementCallback
 import de.digitalService.useID.flows.PinManagementStateMachine
 import de.digitalService.useID.idCardInterface.IdCardInteractionException
@@ -22,8 +23,10 @@ import kotlin.reflect.KClass
 class PinManagementStateMachineTest {
     val pinManagementCallback: PinManagementCallback = mockk()
 
+    private val issueTrackerManager = mockk<IssueTrackerManagerType>(relaxUnitFun = true)
+
     private inline fun <reified NewState: PinManagementStateMachine.State> transition(initialState: PinManagementStateMachine.State, event: PinManagementStateMachine.Event, testScope: TestScope): NewState {
-        val stateMachine = PinManagementStateMachine(initialState)
+        val stateMachine = PinManagementStateMachine(initialState, issueTrackerManager)
         Assertions.assertEquals(stateMachine.state.value.second, initialState)
 
         stateMachine.transition(event)
@@ -535,7 +538,7 @@ class PinManagementStateMachineTest {
     fun invalidate(oldState: PinManagementStateMachine.State) = runTest {
         val event = PinManagementStateMachine.Event.Invalidate
 
-        val stateMachine = PinManagementStateMachine(oldState)
+        val stateMachine = PinManagementStateMachine(oldState, issueTrackerManager)
         Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
         stateMachine.transition(event)
@@ -549,7 +552,7 @@ class PinManagementStateMachineTest {
         fun `start PIN management`(oldState: PinManagementStateMachine.State) = runTest {
             val event = PinManagementStateMachine.Event.StartPinManagement(false, true)
 
-            val stateMachine = PinManagementStateMachine(oldState)
+            val stateMachine = PinManagementStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -560,7 +563,7 @@ class PinManagementStateMachineTest {
         fun `enter old PIN`(oldState: PinManagementStateMachine.State) = runTest {
             val event = PinManagementStateMachine.Event.EnterOldPin("")
 
-            val stateMachine = PinManagementStateMachine(oldState)
+            val stateMachine = PinManagementStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -571,7 +574,7 @@ class PinManagementStateMachineTest {
         fun `confirm PIN intro`(oldState: PinManagementStateMachine.State) = runTest {
             val event = PinManagementStateMachine.Event.ConfirmNewPinIntro
 
-            val stateMachine = PinManagementStateMachine(oldState)
+            val stateMachine = PinManagementStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -582,7 +585,7 @@ class PinManagementStateMachineTest {
         fun `retry PIN confirmation after mismatch`(oldState: PinManagementStateMachine.State) = runTest {
             val event = PinManagementStateMachine.Event.RetryNewPinConfirmation
 
-            val stateMachine = PinManagementStateMachine(oldState)
+            val stateMachine = PinManagementStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -593,7 +596,7 @@ class PinManagementStateMachineTest {
         fun `enter new PIN`(oldState: PinManagementStateMachine.State) = runTest {
             val event = PinManagementStateMachine.Event.EnterNewPin("")
 
-            val stateMachine = PinManagementStateMachine(oldState)
+            val stateMachine = PinManagementStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -604,7 +607,7 @@ class PinManagementStateMachineTest {
         fun `confirm new PIN`(oldState: PinManagementStateMachine.State) = runTest {
             val event = PinManagementStateMachine.Event.ConfirmNewPin("")
 
-            val stateMachine = PinManagementStateMachine(oldState)
+            val stateMachine = PinManagementStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -615,7 +618,7 @@ class PinManagementStateMachineTest {
         fun `request card insertion`(oldState: PinManagementStateMachine.State) = runTest {
             val event = PinManagementStateMachine.Event.RequestCardInsertion
 
-            val stateMachine = PinManagementStateMachine(oldState)
+            val stateMachine = PinManagementStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -626,7 +629,7 @@ class PinManagementStateMachineTest {
         fun `framework requests changed PIN`(oldState: PinManagementStateMachine.State) = runTest {
             val event = PinManagementStateMachine.Event.FrameworkRequestsChangedPin(pinManagementCallback)
 
-            val stateMachine = PinManagementStateMachine(oldState)
+            val stateMachine = PinManagementStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -637,7 +640,7 @@ class PinManagementStateMachineTest {
         fun `framework requests CAN`(oldState: PinManagementStateMachine.State) = runTest {
             val event = PinManagementStateMachine.Event.FrameworkRequestsCan
 
-            val stateMachine = PinManagementStateMachine(oldState)
+            val stateMachine = PinManagementStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -648,7 +651,7 @@ class PinManagementStateMachineTest {
         fun finish(oldState: PinManagementStateMachine.State) = runTest {
             val event = PinManagementStateMachine.Event.Finish
 
-            val stateMachine = PinManagementStateMachine(oldState)
+            val stateMachine = PinManagementStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -659,7 +662,7 @@ class PinManagementStateMachineTest {
         fun `proceed after error`(oldState: PinManagementStateMachine.State) = runTest {
             val event = PinManagementStateMachine.Event.ProceedAfterError
 
-            val stateMachine = PinManagementStateMachine(oldState)
+            val stateMachine = PinManagementStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -670,7 +673,7 @@ class PinManagementStateMachineTest {
         fun `card deactivated`(oldState: PinManagementStateMachine.State) = runTest {
             val event = PinManagementStateMachine.Event.Error(IdCardInteractionException.CardDeactivated)
 
-            val stateMachine = PinManagementStateMachine(oldState)
+            val stateMachine = PinManagementStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -681,7 +684,7 @@ class PinManagementStateMachineTest {
         fun `card blocked`(oldState: PinManagementStateMachine.State) = runTest {
             val event = PinManagementStateMachine.Event.Error(IdCardInteractionException.CardBlocked)
 
-            val stateMachine = PinManagementStateMachine(oldState)
+            val stateMachine = PinManagementStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -693,7 +696,7 @@ class PinManagementStateMachineTest {
         fun `process failed`(oldState: PinManagementStateMachine.State) = runTest {
             val event = PinManagementStateMachine.Event.Error(IdCardInteractionException.ProcessFailed(ActivationResultCode.INTERRUPTED, null, null))
 
-            val stateMachine = PinManagementStateMachine(oldState)
+            val stateMachine = PinManagementStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -705,7 +708,7 @@ class PinManagementStateMachineTest {
         fun back(oldState: PinManagementStateMachine.State) = runTest {
             val event = PinManagementStateMachine.Event.Back
 
-            val stateMachine = PinManagementStateMachine(oldState)
+            val stateMachine = PinManagementStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/stateMachines/SetupStateMachineTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/stateMachines/SetupStateMachineTest.kt
@@ -1,9 +1,11 @@
 package de.digitalService.useID.stateMachines
 
+import de.digitalService.useID.analytics.IssueTrackerManagerType
 import de.digitalService.useID.flows.SetupStateMachine
 import de.digitalService.useID.util.SetupStateFactory
 import de.jodamob.junit5.DefaultTypeFactory
 import de.jodamob.junit5.SealedClassesSource
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -17,8 +19,10 @@ import kotlin.reflect.KClass
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SetupStateMachineTest {
+
+    private val issueTrackerManager = mockk<IssueTrackerManagerType>(relaxUnitFun = true)
     private inline fun <reified NewState: SetupStateMachine.State> transition(initialState: SetupStateMachine.State, event: SetupStateMachine.Event, testScope: TestScope): NewState {
-        val stateMachine = SetupStateMachine(initialState)
+        val stateMachine = SetupStateMachine(initialState, issueTrackerManager)
         Assertions.assertEquals(stateMachine.state.value.second, initialState)
 
         stateMachine.transition(event)
@@ -264,7 +268,7 @@ class SetupStateMachineTest {
     fun invalidate(oldState: SetupStateMachine.State) = runTest {
         val event = SetupStateMachine.Event.Invalidate
 
-        val stateMachine = SetupStateMachine(oldState)
+        val stateMachine = SetupStateMachine(oldState, issueTrackerManager)
         Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
         stateMachine.transition(event)
@@ -278,7 +282,7 @@ class SetupStateMachineTest {
         fun `offer setup`(oldState: SetupStateMachine.State) = runTest {
             val event = SetupStateMachine.Event.OfferSetup(null)
 
-            val stateMachine = SetupStateMachine(oldState)
+            val stateMachine = SetupStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -289,7 +293,7 @@ class SetupStateMachineTest {
         fun `skip setup`(oldState: SetupStateMachine.State) = runTest {
             val event = SetupStateMachine.Event.SkipSetup
 
-            val stateMachine = SetupStateMachine(oldState)
+            val stateMachine = SetupStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -300,7 +304,7 @@ class SetupStateMachineTest {
         fun `start setup`(oldState: SetupStateMachine.State) = runTest {
             val event = SetupStateMachine.Event.StartSetup
 
-            val stateMachine = SetupStateMachine(oldState)
+            val stateMachine = SetupStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -311,7 +315,7 @@ class SetupStateMachineTest {
         fun `PIN reset`(oldState: SetupStateMachine.State) = runTest {
             val event = SetupStateMachine.Event.ResetPin
 
-            val stateMachine = SetupStateMachine(oldState)
+            val stateMachine = SetupStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -322,7 +326,7 @@ class SetupStateMachineTest {
         fun `finish PIN management`(oldState: SetupStateMachine.State) = runTest {
             val event = SetupStateMachine.Event.FinishPinManagement
 
-            val stateMachine = SetupStateMachine(oldState)
+            val stateMachine = SetupStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -333,7 +337,7 @@ class SetupStateMachineTest {
         fun `confirm finish`(oldState: SetupStateMachine.State) = runTest {
             val event = SetupStateMachine.Event.ConfirmFinish
 
-            val stateMachine = SetupStateMachine(oldState)
+            val stateMachine = SetupStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -344,7 +348,7 @@ class SetupStateMachineTest {
         fun `subsequent flow backed down`(oldState: SetupStateMachine.State) = runTest {
             val event = SetupStateMachine.Event.SubsequentFlowBackedDown
 
-            val stateMachine = SetupStateMachine(oldState)
+            val stateMachine = SetupStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }
@@ -355,7 +359,7 @@ class SetupStateMachineTest {
         fun back(oldState: SetupStateMachine.State) = runTest {
             val event = SetupStateMachine.Event.Back
 
-            val stateMachine = SetupStateMachine(oldState)
+            val stateMachine = SetupStateMachine(oldState, issueTrackerManager)
             Assertions.assertEquals(stateMachine.state.value.second, oldState)
 
             Assertions.assertThrows(IllegalArgumentException::class.java) { stateMachine.transition(event) }


### PR DESCRIPTION
This adds information to Sentry error tracking that help us investigating on errors.