### PR TITLE
AbTestManager tests

### DIFF
--- a/app/src/androidTestDeviceDebug/kotlin/de/digitalService/useID/SetupIntroTest.kt
+++ b/app/src/androidTestDeviceDebug/kotlin/de/digitalService/useID/SetupIntroTest.kt
@@ -1,5 +1,6 @@
 package de.digitalService.useID
 
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -98,5 +99,37 @@ class SetupIntroTest {
         composeTestRule.onNodeWithText(secondaryButton).performClick()
 
         verify { viewModel.onNonFirstTimeUsage() }
+    }
+
+    @Test
+    fun showsOriginal() {
+        val viewModel: SetupIntroViewModelInterface = mockk(relaxUnitFun = true) {
+            every { confirmCancellation } returns false
+            every { showVariant } returns false
+        }
+
+        composeTestRule.activity.setContentUsingUseIdTheme {
+            SetupIntro(viewModel = viewModel)
+        }
+
+        val title = composeTestRule.activity.getString(R.string.firstTimeUser_intro_title)
+
+        composeTestRule.onNodeWithText(title).assertIsDisplayed()
+    }
+
+    @Test
+    fun showsVariant() {
+        val viewModel: SetupIntroViewModelInterface = mockk(relaxUnitFun = true) {
+            every { confirmCancellation } returns false
+            every { showVariant } returns true
+        }
+
+        composeTestRule.activity.setContentUsingUseIdTheme {
+            SetupIntro(viewModel = viewModel)
+        }
+
+        val title = composeTestRule.activity.getString(R.string.firstTimeUser_intro_title_variant)
+
+        composeTestRule.onNodeWithText(title).assertIsDisplayed()
     }
 }

--- a/app/src/androidTestDeviceDebug/kotlin/de/digitalService/useID/hilt/MockAbTestModule.kt
+++ b/app/src/androidTestDeviceDebug/kotlin/de/digitalService/useID/hilt/MockAbTestModule.kt
@@ -2,6 +2,7 @@ package de.digitalService.useID.hilt
 
 import dagger.Module
 import dagger.Provides
+import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
 import de.digitalService.useID.util.AbTestManager
@@ -14,6 +15,10 @@ import javax.inject.Singleton
     components = [SingletonComponent::class],
     replaces = [AbTestModule::class]
 )
+class NoAbTestModule
+
+@Module
+@InstallIn(SingletonComponent::class)
 class MockAbTestModule {
 
     @Provides

--- a/app/src/androidTestDeviceDebug/kotlin/de/digitalService/useID/userFlowTests/utils/TestScreen.kt
+++ b/app/src/androidTestDeviceDebug/kotlin/de/digitalService/useID/userFlowTests/utils/TestScreen.kt
@@ -266,8 +266,10 @@ sealed class TestScreen {
 
     data class SetupIntro(override val testRule: ComposeTestRule) : TestScreen() {
 
-        private val title = TestElement.Text(testRule, resourceId = R.string.firstTimeUser_intro_title)
-//        val body = TestElement.Text(R.string.firstTimeUser_intro_body) TODO: reenable when markdown is matchable in UI tests
+        private val title =
+            TestElement.Text(testRule, resourceId = R.string.firstTimeUser_intro_title)
+
+        //        val body = TestElement.Text(R.string.firstTimeUser_intro_body) TODO: reenable when markdown is matchable in UI tests
         private val idsImage = TestElement.Tag(testRule, R.drawable.eid_3.toString())
         val cancel = TestElement.Tag(testRule, NavigationIcon.Cancel.name)
         val setupIdBtn = TestElement.Text(testRule, resourceId = R.string.firstTimeUser_intro_startSetup)
@@ -287,6 +289,32 @@ sealed class TestScreen {
                 )
             }
     }
+
+    data class SetupIntroVariant(override val testRule: ComposeTestRule) : TestScreen() {
+
+        private val title =
+            TestElement.Text(testRule, resourceId = R.string.firstTimeUser_intro_title_variant)
+        //private val body = TestElement.Text(testRule, resourceId = R.string.firstTimeUser_intro_body_variant) // TODO : reenable when markdown is matchable in UI tests
+        //private val idsImage = TestElement.Tag(testRule, R.drawable.img_pin_setup.toString()) // TODO vector image not matchable??
+        val cancel = TestElement.Tag(testRule, NavigationIcon.Cancel.name)
+        val setupIdBtn = TestElement.Text(testRule, resourceId = R.string.firstTimeUser_intro_startSetup)
+        private val alreadySetupBtn = TestElement.Text(testRule, resourceId = R.string.firstTimeUser_intro_skipSetup)
+
+        override val expectedElements: List<TestElement>
+            get() {
+                return listOf(
+                    title, cancel, setupIdBtn, alreadySetupBtn
+                )
+            }
+
+        override val unexpectedElements: List<TestElement>
+            get() {
+                return listOf(
+                    TestElement.Tag(testRule, NavigationIcon.Back.name)
+                )
+            }
+    }
+
 
     data class SetupPinLetter(override val testRule: ComposeTestRule) : TestScreen() {
 

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/managers/AbTestManagerTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/managers/AbTestManagerTest.kt
@@ -1,0 +1,231 @@
+package de.digitalService.useID.managers
+
+import de.digitalService.useID.analytics.IssueTrackerManager
+import de.digitalService.useID.analytics.TrackerManager
+import de.digitalService.useID.util.AbTest
+import de.digitalService.useID.util.AbTestManager
+import de.digitalService.useID.util.UnleashException
+import io.getunleash.UnleashClient
+import io.getunleash.UnleashConfig
+import io.getunleash.UnleashContext
+import io.getunleash.data.Variant
+import io.getunleash.polling.AutoPollingMode
+import io.getunleash.polling.PollingModes
+import io.getunleash.polling.TogglesErroredListener
+import io.getunleash.polling.TogglesUpdatedListener
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(MockKExtension::class)
+class AbTestManagerTest {
+
+    @MockK(relaxUnitFun = true)
+    lateinit var mockTrackerManager: TrackerManager
+
+    @MockK(relaxUnitFun = true)
+    lateinit var mockIssueTrackerManager: IssueTrackerManager
+
+    @MockK
+    lateinit var mockConfig: UnleashConfig
+
+    @MockK
+    lateinit var mockContext: UnleashContext
+
+    @MockK
+    lateinit var mockPollingMode: AutoPollingMode
+
+    private val testApiUrl = "url"
+    private val testApiKey = "key"
+    private val togglesUpdatedListenerSlot = slot<TogglesUpdatedListener>()
+    private val togglesErroredListenerSlot = slot<TogglesErroredListener>()
+
+
+    @BeforeEach
+    fun beforeEach() {
+        every { mockPollingMode.togglesUpdatedListener } returns TogglesUpdatedListener { }
+        every { mockPollingMode.erroredListener } returns TogglesErroredListener { }
+        every { mockPollingMode.pollImmediate } returns true
+        every { mockPollingMode.pollRateDuration } returns 100
+
+        every { mockConfig.proxyUrl } returns "https://unleash.proxy"
+        every { mockConfig.clientKey } returns ""
+        every { mockConfig.httpClientReadTimeout } returns 100
+        every { mockConfig.httpClientConnectionTimeout } returns 100
+        every { mockConfig.httpClientCacheSize } returns 100
+        every { mockConfig.reportMetrics } returns null
+        every { mockConfig.pollingMode } returns mockPollingMode
+
+        mockkObject(PollingModes)
+        every { PollingModes.autoPoll(any()) } returns mockPollingMode
+
+        mockkObject(UnleashConfig.Companion)
+        every {
+            UnleashConfig.Companion.newBuilder()
+                .proxyUrl(testApiUrl)
+                .clientKey(testApiKey)
+                .pollingMode(mockPollingMode)
+                .build()
+        } returns mockConfig
+
+        mockkStatic(UUID::class)
+        every { UUID.randomUUID().toString() } returns ""
+
+        mockkObject(UnleashContext.Companion)
+        every {
+            UnleashContext.newBuilder()
+                .appName("bundesIdent.Android")
+                .sessionId(UUID.randomUUID().toString())
+                .properties(mutableMapOf(Pair("supportedToggles", AbTest.values().joinToString(",") { it.testName })))
+                .build()
+        } returns mockContext
+
+        mockkConstructor(UnleashClient::class)
+        every {
+            anyConstructed<UnleashClient>().addTogglesUpdatedListener(capture(togglesUpdatedListenerSlot))
+        } returns Unit
+        every {
+            anyConstructed<UnleashClient>().addTogglesErroredListener(capture(togglesErroredListenerSlot))
+        } returns Unit
+    }
+
+    @Test
+    fun unleashInitialisation() = runTest {
+        launch {
+            delay(100)
+            togglesUpdatedListenerSlot.captured.onTogglesUpdated()
+        }
+
+        val abTestManager = AbTestManager(testApiUrl, testApiKey, mockTrackerManager, mockIssueTrackerManager)
+        abTestManager.initialise()
+
+        verify {
+            UnleashConfig.newBuilder()
+                .proxyUrl(testApiUrl)
+                .clientKey(testApiKey)
+                .pollingMode(mockPollingMode)
+                .build()
+        }
+
+        verify {
+            UnleashContext.newBuilder()
+                .appName("bundesIdent.Android")
+                .sessionId(UUID.randomUUID().toString())
+                .properties(mutableMapOf(Pair("supportedToggles", AbTest.values().joinToString(",") { it.testName })))
+                .build()
+        }
+
+        verify {
+            anyConstructed<UnleashClient>().addTogglesUpdatedListener(togglesUpdatedListenerSlot.captured)
+        }
+        verify {
+            anyConstructed<UnleashClient>().addTogglesErroredListener(togglesErroredListenerSlot.captured)
+        }
+    }
+
+    @Test
+    fun togglesUpdateWithVariationVariant() = runTest {
+        val mockVariant = mockk<Variant> {
+            every { name } returns "Variation"
+        }
+
+        every { anyConstructed<UnleashClient>().isEnabled(any()) } returns true
+        every { anyConstructed<UnleashClient>().getVariant(any()) } returns mockVariant
+
+        launch {
+            delay(100)
+            togglesUpdatedListenerSlot.captured.onTogglesUpdated()
+            delay(100)
+        }
+
+        val abTestManager = AbTestManager(testApiUrl, testApiKey, mockTrackerManager, mockIssueTrackerManager)
+        abTestManager.initialise()
+
+        val testName = AbTest.SETUP_INTRODUCTION_EXPLANATION.testName.replace(".", "_")
+        verify { mockTrackerManager.trackEvent("abtesting", testName, "Variation") }
+        assertTrue(abTestManager.isSetupIntroTestVariant.value)
+    }
+
+    @Test
+    fun togglesUpdateWithDisabledToggle() = runTest {
+        every { anyConstructed<UnleashClient>().isEnabled(any()) } returns false
+
+        launch {
+            delay(100)
+            togglesUpdatedListenerSlot.captured.onTogglesUpdated()
+            delay(100)
+        }
+
+        val abTestManager = AbTestManager(testApiUrl, testApiKey, mockTrackerManager, mockIssueTrackerManager)
+        abTestManager.initialise()
+
+        val testName = AbTest.SETUP_INTRODUCTION_EXPLANATION.testName.replace(".", "_")
+        verify(exactly = 0) { mockTrackerManager.trackEvent(any(), any(), any()) }
+        assertFalse(abTestManager.isSetupIntroTestVariant.value)
+    }
+
+    @Test
+    fun togglesUpdateWithOriginalVariant() = runTest {
+        every { anyConstructed<UnleashClient>().isEnabled(any()) } returns false
+
+        launch {
+            delay(100)
+            togglesUpdatedListenerSlot.captured.onTogglesUpdated()
+            delay(100)
+        }
+
+        val mockVariant = mockk<Variant> {
+            every { name } returns "Original"
+        }
+
+        every { anyConstructed<UnleashClient>().isEnabled(any()) } returns true
+        every { anyConstructed<UnleashClient>().getVariant(any()) } returns mockVariant
+
+        val abTestManager = AbTestManager(testApiUrl, testApiKey, mockTrackerManager, mockIssueTrackerManager)
+        abTestManager.initialise()
+
+        val testName = AbTest.SETUP_INTRODUCTION_EXPLANATION.testName.replace(".", "_")
+        verify { mockTrackerManager.trackEvent("abtesting", testName, "Original") }
+        assertFalse(abTestManager.isSetupIntroTestVariant.value)
+    }
+
+    @Test
+    fun testTogglesErrored() = runTest {
+        val exception = Exception()
+
+        launch {
+            delay(100)
+            togglesErroredListenerSlot.captured.onError(exception)
+        }
+
+        val abTestManager = AbTestManager(testApiUrl, testApiKey, mockTrackerManager, mockIssueTrackerManager)
+        abTestManager.initialise()
+
+        verify { mockIssueTrackerManager.capture(exception) }
+        assertFalse(abTestManager.isSetupIntroTestVariant.value)
+    }
+
+    @Test
+    fun initialisationCancelled() = runTest {
+        val abTestManager = AbTestManager(testApiUrl, testApiKey, mockTrackerManager, mockIssueTrackerManager)
+        val job = launch {
+            abTestManager.initialise()
+        }
+        launch {
+            delay(100)
+            job.cancel()
+            verify { mockIssueTrackerManager.capture(withArg { (UnleashException("Timed out while fetching toggles.")) }) }
+            assertFalse(abTestManager.isSetupIntroTestVariant.value)
+        }
+    }
+}


### PR DESCRIPTION
- adds unit tests for `AbTestManager` class
- adds tests cases for the `SetupIntroTest` UI test for showing original and variation versions of the screen
- adds a test flow for successful setup with the variation version of the `SetupIntro` screen