### PR TITLE
Update gradle-dependency-submission workflow

### DIFF
--- a/.github/workflows/Dependencies.yml
+++ b/.github/workflows/Dependencies.yml
@@ -2,12 +2,19 @@ name: Submits dependencies to repository's dependency graph
 on:
   push:
     branches:
-      - develop
+      - main
 
 jobs:
+  validate-gradle-wrapper:
+    runs-on: [self-hosted, ARM64]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Validate gradle wrapper
+        uses: gradle/wrapper-validation-action@8d49e559aae34d3e0eb16cde532684bc9702762b
   build:
     name: Dependencies
     runs-on: [self-hosted, ARM64]
+    needs: [validate-gradle-wrapper]
     permissions:
       contents: write
     steps:
@@ -18,6 +25,6 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Gradle Dependency Submission
-        uses: mikepenz/gradle-dependency-submission@v0.8.5
+        uses: mikepenz/gradle-dependency-submission@aa82af7186ba17eb630a7d47c840ba8a3185ac91
         with:
           gradle-build-module: ":app"


### PR DESCRIPTION
* Use correct branch ('main' instead of 'develop')
* Validate Gradle wrapper before executing Gradle
* Update gradle-dependency-submission to v0.8.6 (aa82af7)

The actions are pinned to Git SHA instead of version tag, see
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions