### PR TITLE
Tracking

### DIFF
--- a/app/src/debug/kotlin/de/digitalService/useID/analytics/TrackerManager.kt
+++ b/app/src/debug/kotlin/de/digitalService/useID/analytics/TrackerManager.kt
@@ -12,5 +12,7 @@ class TrackerManager @Inject constructor() : TrackerManagerType {
     override fun initTracker(context: Context) {}
     override fun trackScreen(route: String) = logger.debug("Track Screen: $route")
     override fun trackEvent(category: String, action: String, name: String) = logger.debug("Track event: $category, $action, $name")
+
+    override fun trackButtonPressed(category: String, name: String) = logger.debug("Track button pressed: $category, $name")
     override fun dispatch() {}
 }

--- a/app/src/main/kotlin/de/digitalService/useID/analytics/TrackerManagerType.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/analytics/TrackerManagerType.kt
@@ -6,5 +6,7 @@ interface TrackerManagerType {
     fun initTracker(context: Context)
     fun trackScreen(route: String)
     fun trackEvent(category: String, action: String, name: String)
+
+    fun trackButtonPressed(category: String, name: String)
     fun dispatch()
 }

--- a/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/AppCoordinator.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/coordinators/AppCoordinator.kt
@@ -2,6 +2,7 @@ package de.digitalService.useID.ui.coordinators
 
 import android.net.Uri
 import de.digitalService.useID.StorageManagerType
+import de.digitalService.useID.analytics.TrackerManagerType
 import de.digitalService.useID.getLogger
 import de.digitalService.useID.models.NfcAvailability
 import de.digitalService.useID.ui.navigation.Navigator
@@ -28,7 +29,8 @@ class AppCoordinator @Inject constructor(
     private val setupCoordinator: SetupCoordinator,
     private val identificationCoordinator: IdentificationCoordinator,
     private val storageManager: StorageManagerType,
-    private val coroutineContextProvider: CoroutineContextProviderType
+    private val coroutineContextProvider: CoroutineContextProviderType,
+    private val trackerManager: TrackerManagerType
 ) : AppCoordinatorType {
     private val logger by getLogger()
 
@@ -52,6 +54,7 @@ class AppCoordinator @Inject constructor(
 
     override fun offerIdSetup(tcTokenUrl: String?) {
         navigator.popToRoot()
+        trackerManager.trackEvent("firstTimeUser", "setupIntroOpened", tcTokenUrl?.let { "widget" } ?: "home")
         setupCoordinator.showSetupIntro(tcTokenUrl)
     }
 

--- a/app/src/main/kotlin/de/digitalService/useID/ui/previewMocks/PreviewTrackerManager.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/previewMocks/PreviewTrackerManager.kt
@@ -7,5 +7,6 @@ class PreviewTrackerManager : TrackerManagerType {
     override fun initTracker(context: Context) {}
     override fun trackScreen(route: String) {}
     override fun trackEvent(category: String, action: String, name: String) {}
+    override fun trackButtonPressed(category: String, name: String) {}
     override fun dispatch() {}
 }

--- a/app/src/main/kotlin/de/digitalService/useID/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/screens/HomeScreen.kt
@@ -285,7 +285,7 @@ class HomeScreenViewModel @Inject constructor(
 
     override fun setupOnlineId() {
         appCoordinator.offerIdSetup(null)
-        trackerManager.trackEvent(category = "firstTimeUser", action = "buttonPressed", name = "start")
+        trackerManager.trackButtonPressed(category = "firstTimeUser", "start")
     }
 
     override fun onPrivacyButtonClicked() {

--- a/app/src/main/kotlin/de/digitalService/useID/ui/screens/setup/SetupIntro.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/screens/setup/SetupIntro.kt
@@ -142,12 +142,12 @@ class SetupIntroViewModel @Inject constructor(
     }
 
     override fun onFirstTimeUsage() {
-        trackerManager.trackEvent("firstTimeUser", "buttonPressed", "startSetup")
+        trackerManager.trackButtonPressed("firstTimeUser", "startSetup")
         setupCoordinator.startSetupIdCard()
     }
 
     override fun onNonFirstTimeUsage() {
-        trackerManager.trackEvent("firstTimeUser", "buttonPressed", "alreadySetup")
+        trackerManager.trackButtonPressed("firstTimeUser", "alreadySetup")
         setupCoordinator.skipSetup()
     }
 

--- a/app/src/main/kotlin/de/digitalService/useID/ui/screens/setup/SetupIntro.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/ui/screens/setup/SetupIntro.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.ViewModel
 import com.ramcosta.composedestinations.annotation.Destination
 import dagger.hilt.android.lifecycle.HiltViewModel
 import de.digitalService.useID.R
+import de.digitalService.useID.analytics.TrackerManagerType
 import de.digitalService.useID.ui.components.*
 import de.digitalService.useID.ui.coordinators.SetupCoordinator
 import de.digitalService.useID.ui.screens.destinations.SetupIntroDestination
@@ -128,6 +129,7 @@ interface SetupIntroViewModelInterface {
 @HiltViewModel
 class SetupIntroViewModel @Inject constructor(
     private val setupCoordinator: SetupCoordinator,
+    private val trackerManager: TrackerManagerType,
     abTestManager: AbTestManager,
     savedStateHandle: SavedStateHandle
 ) : ViewModel(), SetupIntroViewModelInterface {
@@ -140,10 +142,12 @@ class SetupIntroViewModel @Inject constructor(
     }
 
     override fun onFirstTimeUsage() {
+        trackerManager.trackEvent("firstTimeUser", "buttonPressed", "startSetup")
         setupCoordinator.startSetupIdCard()
     }
 
     override fun onNonFirstTimeUsage() {
+        trackerManager.trackEvent("firstTimeUser", "buttonPressed", "alreadySetup")
         setupCoordinator.skipSetup()
     }
 

--- a/app/src/release/kotlin/de/digitalService/useID/analytics/TrackerManager.kt
+++ b/app/src/release/kotlin/de/digitalService/useID/analytics/TrackerManager.kt
@@ -39,6 +39,10 @@ class TrackerManager @Inject constructor(
         updateSession()
     }
 
+    override fun trackButtonPressed(category: String, name: String) {
+        trackEvent(category, "buttonPressed", name)
+    }
+
     override fun dispatch() {
         tracker.dispatch()
     }

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/viewModel/HomeViewModelTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/viewModel/HomeViewModelTest.kt
@@ -53,7 +53,7 @@ class HomeViewModelTest {
         viewModel.setupOnlineId()
 
         verify(exactly = 1) { mockAppCoordinator.offerIdSetup(null) }
-        verify(exactly = 1) { mockTrackerManager.trackEvent("firstTimeUser", "buttonPressed", "start") }
+        verify(exactly = 1) { mockTrackerManager.trackButtonPressed("firstTimeUser", "start") }
     }
 
     @Test

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/viewModel/SetupIntroViewModelTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/viewModel/SetupIntroViewModelTest.kt
@@ -52,7 +52,7 @@ class SetupIntroViewModelTest {
         viewModel.onFirstTimeUsage()
 
         verify(exactly = 1) { mockSetupCoordinator.startSetupIdCard() }
-        verify(exactly = 1) { mockTrackerManager.trackEvent("firstTimeUser", "buttonPressed", "startSetup") }
+        verify(exactly = 1) { mockTrackerManager.trackButtonPressed("firstTimeUser", "startSetup") }
     }
 
     @Test
@@ -62,7 +62,7 @@ class SetupIntroViewModelTest {
         viewModel.onNonFirstTimeUsage()
 
         verify(exactly = 1) { mockSetupCoordinator.skipSetup() }
-        verify(exactly = 1) { mockTrackerManager.trackEvent("firstTimeUser", "buttonPressed", "alreadySetup") }
+        verify(exactly = 1) { mockTrackerManager.trackButtonPressed("firstTimeUser", "alreadySetup") }
     }
 
     @ParameterizedTest

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/viewModel/SetupIntroViewModelTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/viewModel/SetupIntroViewModelTest.kt
@@ -1,0 +1,87 @@
+package de.digitalService.useID.viewModel
+
+import androidx.lifecycle.SavedStateHandle
+import de.digitalService.useID.analytics.TrackerManagerType
+import de.digitalService.useID.ui.coordinators.SetupCoordinator
+import de.digitalService.useID.ui.screens.destinations.SetupIntroDestination
+import de.digitalService.useID.ui.screens.setup.SetupIntroNavArgs
+import de.digitalService.useID.ui.screens.setup.SetupIntroViewModel
+import de.digitalService.useID.util.AbTestManager
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockkObject
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+@ExtendWith(MockKExtension::class)
+class SetupIntroViewModelTest {
+
+    @MockK(relaxUnitFun = true)
+    lateinit var mockSetupCoordinator: SetupCoordinator
+
+    @MockK(relaxUnitFun = true)
+    lateinit var mockTrackerManager: TrackerManagerType
+
+    @MockK(relaxUnitFun = true)
+    lateinit var mockAbTestManager: AbTestManager
+
+    @MockK(relaxUnitFun = true)
+    lateinit var mockSaveStateHandle: SavedStateHandle
+
+    @MockK
+    lateinit var mockNavArgs: SetupIntroNavArgs
+
+    @BeforeEach
+    fun setup() {
+        mockkObject(SetupIntroDestination)
+        every { SetupIntroDestination.argsFrom(mockSaveStateHandle) } returns mockNavArgs
+        every { mockNavArgs.confirmCancellation } returns false
+        every { mockAbTestManager.isSetupIntroTestVariant.value } returns false
+    }
+
+    @Test
+    fun onOnFirstTimeUsage() {
+        val viewModel = SetupIntroViewModel(mockSetupCoordinator, mockTrackerManager, mockAbTestManager, mockSaveStateHandle)
+
+        viewModel.onFirstTimeUsage()
+
+        verify(exactly = 1) { mockSetupCoordinator.startSetupIdCard() }
+        verify(exactly = 1) { mockTrackerManager.trackEvent("firstTimeUser", "buttonPressed", "startSetup") }
+    }
+
+    @Test
+    fun onNonFirstTimeUsage() {
+        val viewModel = SetupIntroViewModel(mockSetupCoordinator, mockTrackerManager, mockAbTestManager, mockSaveStateHandle)
+
+        viewModel.onNonFirstTimeUsage()
+
+        verify(exactly = 1) { mockSetupCoordinator.skipSetup() }
+        verify(exactly = 1) { mockTrackerManager.trackEvent("firstTimeUser", "buttonPressed", "alreadySetup") }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun testShowVariant(isVariant: Boolean) {
+        every { mockAbTestManager.isSetupIntroTestVariant.value } returns isVariant
+
+        val viewModel = SetupIntroViewModel(mockSetupCoordinator, mockTrackerManager, mockAbTestManager, mockSaveStateHandle)
+
+        Assertions.assertEquals(isVariant, viewModel.showVariant)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun testConfirmCancellation(confirmCancellation: Boolean) {
+        every { mockNavArgs.confirmCancellation } returns confirmCancellation
+
+        val viewModel = SetupIntroViewModel(mockSetupCoordinator, mockTrackerManager, mockAbTestManager, mockSaveStateHandle)
+
+        Assertions.assertEquals(confirmCancellation, viewModel.confirmCancellation)
+    }
+}

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/viewModel/SetupIntroViewModelTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/viewModel/SetupIntroViewModelTest.kt
@@ -42,7 +42,7 @@ class SetupIntroViewModelTest {
         mockkObject(SetupIntroDestination)
         every { SetupIntroDestination.argsFrom(mockSaveStateHandle) } returns mockNavArgs
         every { mockNavArgs.confirmCancellation } returns false
-        every { mockAbTestManager.isSetupIntroTestVariant.value } returns false
+        every { mockAbTestManager.isSetupIntroTestVariation.value } returns false
     }
 
     @Test
@@ -68,11 +68,11 @@ class SetupIntroViewModelTest {
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
     fun testShowVariant(isVariant: Boolean) {
-        every { mockAbTestManager.isSetupIntroTestVariant.value } returns isVariant
+        every { mockAbTestManager.isSetupIntroTestVariation.value } returns isVariant
 
         val viewModel = SetupIntroViewModel(mockSetupCoordinator, mockTrackerManager, mockAbTestManager, mockSaveStateHandle)
 
-        Assertions.assertEquals(isVariant, viewModel.showVariant)
+        Assertions.assertEquals(isVariant, viewModel.showVariation)
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Adds additional tracking for setup intro screen to give us more data when evaluating the A/B test results. 

Added events: 
- when setup intro screen is presented, indicating wether the source is widget or home screen
  - Category: “firstTimeUser”, Action: “setupIntroOpened”, Name: “widget”/“home”
- when tapping “Jetzt Online-Ausweis einrichten” for both control and variation of the test
  - Category: “firstTimeUser”, Action: “buttonPressed”, Name: “startSetup”
- when tapping “Bereits eingerichtet” for both control and variation of the test
  - Category: “firstTimeUser”, Action: “buttonPressed”, Name: “alreadySetup”