### PR TITLE
Release

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -45,7 +45,7 @@ runs:
         path: |
           vendor
           .bundle
-        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-${{ runner.name }}-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock') }}
     - name: Install dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
       shell: bash
@@ -59,5 +59,5 @@ runs:
         path: |
           vendor
           .bundle
-        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-${{ runner.name }}-${{ env.cache-name }}-${{ hashFiles('Gemfile.lock') }}
     # <-- Workaround

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -44,6 +44,10 @@ jobs:
     runs-on: [self-hosted, ARM64]
     needs: bumpVersion
     steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.bumpVersion.outputs.gitTag }}
       - name: Build
         uses: ./.github/actions/release
         with:
@@ -66,6 +70,10 @@ jobs:
     runs-on: [self-hosted, ARM64]
     needs: bumpVersion
     steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.bumpVersion.outputs.gitTag }}
       - name: Build
         uses: ./.github/actions/release
         with:
@@ -88,6 +96,10 @@ jobs:
     runs-on: [self-hosted, ARM64]
     needs: bumpVersion
     steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.bumpVersion.outputs.gitTag }}
       - name: Build
         uses: ./.github/actions/release
         with:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ android {
         applicationId "de.digitalService.useID"
         minSdk 28
         targetSdk 33
-        versionCode 55
+        versionCode 56
         versionName "1.8.0"
 
         testInstrumentationRunner "de.digitalService.useID.util.HiltTestRunner"


### PR DESCRIPTION
This adds two changes to the GitHub actions workflows:
- As we use multiple runners now we need to add checkout steps to the jobs that might get executed on a different runner than the previous job.
- We use separate ruby caches for each runner as a workaround for the ruby environment being a little different on both runners which prevents a single cache from working on both. This should be investigated and mitigated in the future.