### PR TITLE
AA2 fixes

### DIFF
--- a/app/src/device/kotlin/de/digitalService/useID/idCardInterface/EidInteractionManager.kt
+++ b/app/src/device/kotlin/de/digitalService/useID/idCardInterface/EidInteractionManager.kt
@@ -241,7 +241,9 @@ class EidInteractionManager @Inject constructor(
     fun cancelTask() {
         logger.debug("Stopping workflow controller.")
         workflowController.unregisterCallbacks(workflowCallbacks)
-        workflowController.stop()
+        if (workflowController.isStarted) {
+            workflowController.stop()
+        }
         workflowControllerStarted.value = false
         _eidFlow.value = EidInteractionEvent.Idle
     }

--- a/app/src/main/kotlin/de/digitalService/useID/flows/IdentificationStateMachine.kt
+++ b/app/src/main/kotlin/de/digitalService/useID/flows/IdentificationStateMachine.kt
@@ -88,16 +88,16 @@ class IdentificationStateMachine(initialState: State, private val issueTrackerMa
                 }
             }
 
-            is Event.CertificateDescriptionReceived -> {
+            is Event.FrameworkRequestsAttributeConfirmation -> {
                 when (val currentState = state.value.second) {
-                    is State.RequestCertificate -> State.CertificateDescriptionReceived(currentState.backingDownAllowed, currentState.request, event.certificateDescription)
+                    is State.FetchingMetadata -> State.RequestCertificate(currentState.backingDownAllowed, event.authenticationRequest)
                     else -> throw IllegalArgumentException()
                 }
             }
 
-            is Event.FrameworkRequestsAttributeConfirmation -> {
+            is Event.CertificateDescriptionReceived -> {
                 when (val currentState = state.value.second) {
-                    is State.FetchingMetadata -> State.RequestCertificate(currentState.backingDownAllowed, event.authenticationRequest)
+                    is State.RequestCertificate -> State.CertificateDescriptionReceived(currentState.backingDownAllowed, currentState.request, event.certificateDescription)
                     else -> throw IllegalArgumentException()
                 }
             }
@@ -173,7 +173,7 @@ class IdentificationStateMachine(initialState: State, private val issueTrackerMa
 
             is Event.Back -> {
                 when (val currentState = state.value.second) {
-                    is State.FetchingMetadata, is State.RequestCertificate, is State.CertificateDescriptionReceived -> State.Invalid
+                    is State.StartIdentification, is State.FetchingMetadata, is State.RequestCertificate, is State.CertificateDescriptionReceived -> State.Invalid
                     is State.PinInput -> State.CertificateDescriptionReceived(currentState.backingDownAllowed, currentState.authenticationRequest, currentState.certificateDescription)
                     else -> throw IllegalArgumentException()
                 }

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/IdentificationCoordinatorTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/coordinator/IdentificationCoordinatorTest.kt
@@ -168,9 +168,10 @@ class IdentificationCoordinatorTest {
             verify { mockIdentificationStateMachine.transition(IdentificationStateMachine.Event.Invalidate) }
         }
 
-        @Test
-        fun `start identification`() = runTest {
-            val state = IdentificationStateMachine.State.StartIdentification(false, testTokenUri)
+        @ParameterizedTest
+        @ValueSource(booleans = [true, false])
+        fun `start identification`(backingDownAllowed: Boolean) = runTest {
+            val state = IdentificationStateMachine.State.StartIdentification(backingDownAllowed, testTokenUri)
 
             val identificationCoordinator = IdentificationCoordinator(
                 mockContext,
@@ -191,6 +192,10 @@ class IdentificationCoordinatorTest {
             advanceUntilIdle()
 
             verify { mockEidInteractionManager.identify(mockContext, testTokenUri) }
+
+            verify { mockNavigator.popUpToOrNavigate(any(), false) }
+
+            Assertions.assertEquals(IdentificationFetchMetadataDestination(backingDownAllowed).route, navigationPopUpToOrNavigateDestinationSlot.captured.route)
         }
 
         @ParameterizedTest
@@ -198,10 +203,6 @@ class IdentificationCoordinatorTest {
         fun `fetching metadata`(backingDownAllowed: Boolean) = runTest {
             val state = IdentificationStateMachine.State.FetchingMetadata(backingDownAllowed, testTokenUri)
             testTransition(IdentificationStateMachine.Event.Invalidate, state, this)
-
-            verify { mockNavigator.popUpToOrNavigate(any(), false) }
-
-            Assertions.assertEquals(IdentificationFetchMetadataDestination(backingDownAllowed).route, navigationPopUpToOrNavigateDestinationSlot.captured.route)
         }
 
         @ParameterizedTest

--- a/app/src/testDeviceRelease/kotlin/de/digitalService/useID/stateMachines/IdentificationStateMachineTest.kt
+++ b/app/src/testDeviceRelease/kotlin/de/digitalService/useID/stateMachines/IdentificationStateMachineTest.kt
@@ -450,7 +450,7 @@ class IdentificationStateMachineTest {
         }
 
         @ParameterizedTest
-        @SealedClassesSource(names = ["FetchingMetadata", "RequestCertificate", "CertificateDescriptionReceived", "PinInput"], mode = SealedClassesSource.Mode.EXCLUDE, factoryClass = IdentificationStateFactory::class)
+        @SealedClassesSource(names = ["StartIdentification", "FetchingMetadata", "RequestCertificate", "CertificateDescriptionReceived", "PinInput"], mode = SealedClassesSource.Mode.EXCLUDE, factoryClass = IdentificationStateFactory::class)
         fun back(oldState: IdentificationStateMachine.State) = runTest {
             val event = IdentificationStateMachine.Event.Back
             val stateMachine = IdentificationStateMachine(oldState, issueTrackerManager)


### PR DESCRIPTION
- Show loading straight away when starting an identification flow without waiting for the framework callback `onAuthenticationStarted` so that the user gets instant feedback and can't accidentally start the authentication flow multiple times
- Only stop the workflow controller if it is in started state since calling it multiple times in a row can lead to an error in the framework.